### PR TITLE
加了个反向代理地址的配置

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ mod_name=TrueUUID
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU LGPL 3.0
 # The mod version. See https://semver.org/
-mod_version=1.0.4
+mod_version=1.0.5
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/cn/alini/trueuuid/Trueuuid.java
+++ b/src/main/java/cn/alini/trueuuid/Trueuuid.java
@@ -33,7 +33,7 @@ public class Trueuuid {
         } else {
             // =====MoJang网络连通性测试=====
             try {
-                String testUrl = "https://sessionserver.mojang.com/session/minecraft/hasJoined?username=Mojang&serverId=test";
+                String testUrl = TrueuuidConfig.COMMON.mojangReverseProxy.get()+"/session/minecraft/hasJoined?username=Mojang&serverId=test";
                 java.net.URL url = new java.net.URL(testUrl);
                 java.net.HttpURLConnection conn = (java.net.HttpURLConnection) url.openConnection();
                 conn.setRequestMethod("GET");

--- a/src/main/java/cn/alini/trueuuid/command/TrueuuidCommands.java
+++ b/src/main/java/cn/alini/trueuuid/command/TrueuuidCommands.java
@@ -192,7 +192,7 @@ public class TrueuuidCommands {
 
     private static int mojangStatus(CommandSourceStack src) {
         try {
-            String testUrl = "https://sessionserver.mojang.com/session/minecraft/hasJoined?username=Mojang&serverId=test";
+            String testUrl = TrueuuidConfig.COMMON.mojangReverseProxy.get()+"/session/minecraft/hasJoined?username=Mojang&serverId=test";
             java.net.URL url = new java.net.URL(testUrl);
             java.net.HttpURLConnection conn = (java.net.HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");

--- a/src/main/java/cn/alini/trueuuid/config/TrueuuidConfig.java
+++ b/src/main/java/cn/alini/trueuuid/config/TrueuuidConfig.java
@@ -40,6 +40,7 @@ public final class TrueuuidConfig {
     public static boolean debug() { return COMMON.debug.get(); }
     // 新增 nomojang 开关访问器
     public static boolean nomojangEnabled() { return COMMON.nomojangEnabled.get(); }
+    public static String mojangReverseProxy() { return COMMON.mojangReverseProxy.get(); }
 
     public static final class Common {
         public final ModConfigSpec.LongValue timeoutMs;
@@ -54,6 +55,7 @@ public final class TrueuuidConfig {
 
         // 新增 nomojang 配置
         public final ModConfigSpec.BooleanValue nomojangEnabled;
+        public final ModConfigSpec.ConfigValue<String> mojangReverseProxy;
 
         // 新增：策略相关
         public final ModConfigSpec.BooleanValue knownPremiumDenyOffline;
@@ -92,6 +94,7 @@ public final class TrueuuidConfig {
             // 新增：跳过 Mojang 会话认证（开启后不再通过 sessionserver 验证）
             nomojangEnabled = b.comment("开启后关闭对 Mojang 会话服务的在线校验逻辑；同 IP 且近期有正版成功的名称按正版 UUID 处理，其余直接按离线进入处理。")
                     .define("nomojang.enabled", false);
+            mojangReverseProxy = b.comment("mojang的反代地址,专门为那些不想给服务器开代理的人使用,默认为mojang地址").define("mojangReverseProxy", "https://sessionserver.mojang.com");
             b.pop();
         }
     }

--- a/src/main/java/cn/alini/trueuuid/server/SessionCheck.java
+++ b/src/main/java/cn/alini/trueuuid/server/SessionCheck.java
@@ -1,6 +1,7 @@
 // java
 package cn.alini.trueuuid.server;
 
+import cn.alini.trueuuid.config.TrueuuidConfig;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 
@@ -42,7 +43,7 @@ public final class SessionCheck {
      * 异步版本：不阻塞调用线程，返回 CompletableFuture\<Optional\<HasJoinedResult\>\>
      */
     public static CompletableFuture<Optional<HasJoinedResult>> hasJoinedAsync(String username, String serverId, String ip) {
-        String url = "https://sessionserver.mojang.com/session/minecraft/hasJoined"
+        String url = TrueuuidConfig.COMMON.mojangReverseProxy.get()+"/session/minecraft/hasJoined"
                 + "?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8)
                 + "&serverId=" + URLEncoder.encode(serverId, StandardCharsets.UTF_8);
 


### PR DESCRIPTION
加了个反向代理地址的配置,当用户设置了sessionserver.mojang.com的反向代理时,可以使用配置修改鉴权url,避免minecraft服务器需要使用代理导致玩家高ping.

因此mod可以通过我自己稳定的https://**sessionproxy.example.com**/session/minecraft/hasJoined?username=...&serverId=... 来进行鉴权,避免经常出现鉴权失败

示例(因为我是nginx-proxy-manager配置的反代,所以可能有些不准确,建议询问AI):
server {
  listen 443 ssl;
  server_name sessionproxy.example.com;

  ssl_certificate     /path/to/fullchain.pem;
  ssl_certificate_key /path/to/privkey.pem;

  location = /session/minecraft/hasJoined/ { return 308 /session/minecraft/hasJoined; }

  location ^~ /session/minecraft/hasJoined {
    proxy_pass https://sessionserver.mojang.com$request_uri;
    proxy_set_header Host sessionserver.mojang.com;
    proxy_ssl_server_name on;
    proxy_ssl_name sessionserver.mojang.com;
  }

  location / { return 404; }
}