### PR TITLE
Fix login skin refresh packet target

### DIFF
--- a/src/main/java/cn/alini/trueuuid/server/SkinRefreshHandler.java
+++ b/src/main/java/cn/alini/trueuuid/server/SkinRefreshHandler.java
@@ -34,8 +34,13 @@ public class SkinRefreshHandler {
         // 1) 登录后一帧刷新外观（强制客户端重拉皮肤） (Refresh skin one frame after login (force client to re-fetch skin))
         server.execute(() -> {
             var list = server.getPlayerList();
-            list.broadcastAll(new ClientboundPlayerInfoRemovePacket(List.of(sp.getUUID())));
-            list.broadcastAll(ClientboundPlayerInfoUpdatePacket.createPlayerInitializing(List.of(sp)));
+            var removePacket = new ClientboundPlayerInfoRemovePacket(List.of(sp.getUUID()));
+            var updatePacket = ClientboundPlayerInfoUpdatePacket.createPlayerInitializing(List.of(sp));
+            for (ServerPlayer player : list.getPlayers()) {
+                if (player.getUUID().equals(sp.getUUID())) continue;
+                player.connection.send(removePacket);
+                player.connection.send(updatePacket);
+            }
         });
 
         // 2) 判断是否离线放行，并发送聊天提示 + 屏幕标题（副标题使用短文案） (Determine if offline fallback is active, and send chat notification + screen title (subtitle uses short text))


### PR DESCRIPTION
## Summary
- Skip sending login-time PlayerInfo remove/add refresh packets back to the joining player.
- Keep sending the refresh packets to other online players so the joining player's skin is still refreshed for everyone else.
- Avoid client-side self PlayerInfo removal/re-addition, which can cause visible skin/tab/game-mode state flicker.

## Verification
- Ran `./gradlew.bat build` successfully on the PR branch before publishing.

## Scope
- This PR only changes `SkinRefreshHandler.java`.
- The VC/compatibility changes are already included in upstream `1.20` via the existing history.