### PR TITLE
Add Velocity proxy grace for known premium players

### DIFF
--- a/src/main/java/cn/alini/trueuuid/server/AuthDecider.java
+++ b/src/main/java/cn/alini/trueuuid/server/AuthDecider.java
@@ -19,6 +19,18 @@ public final class AuthDecider {
 
         boolean known = TrueuuidRuntime.NAME_REGISTRY.isKnownPremiumName(name);
 
+        // Velocity/VC proxy compatibility: if the modded client answered the
+        // trueuuid:auth query but Mojang hasJoined still fails behind a local
+        // proxy, preserve the already-bound premium UUID instead of denying.
+        if (known && isLocalProxyAddress(ip)) {
+            Optional<UUID> premiumUuid = TrueuuidRuntime.NAME_REGISTRY.getPremiumUuid(name);
+            if (premiumUuid.isPresent()) {
+                d.kind = Decision.Kind.PREMIUM_GRACE;
+                d.premiumUuid = premiumUuid.get();
+                return d;
+            }
+        }
+
         // 1) 已验证过正版的名字：禁止离线回落 (Names already verified as premium: Deny offline fallback)
         if (known && TrueuuidConfig.knownPremiumDenyOffline()) {
             d.kind = Decision.Kind.DENY;
@@ -46,6 +58,16 @@ public final class AuthDecider {
         d.kind = Decision.Kind.DENY;
         d.denyMessage = "鉴权失败，已禁止离线进入以保护你的正版存档。请稍后重试。";
         return d;
+    }
+
+    private static boolean isLocalProxyAddress(String ip) {
+        if (ip == null || ip.isBlank()) {
+            return false;
+        }
+        return "127.0.0.1".equals(ip)
+                || "0:0:0:0:0:0:0:1".equals(ip)
+                || "::1".equals(ip)
+                || "localhost".equalsIgnoreCase(ip);
     }
 
     private AuthDecider() {}


### PR DESCRIPTION
## Summary
- Add a narrowly scoped Velocity/VC proxy compatibility fallback for already-known premium names.
- Preserve the registered premium UUID when Mojang hasJoined fails behind a local proxy address.

## Scope
- Only changes `AuthDecider.java`.
- Does not alter normal successful Mojang authentication.
- Does not allow unknown names to bypass authentication.

## Verification
- Built successfully with `gradlew.bat --no-daemon clean build` on Java 17.