### PR TITLE
修复 1.20 代理登录流水线重复初始化

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ mod_name=TrueUUID
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU LGPL 3.0
 # The mod version. See https://semver.org/
-mod_version=1.0.4
+mod_version=1.0.6
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/cn/alini/trueuuid/mixin/server/ServerLoginMixin.java
+++ b/src/main/java/cn/alini/trueuuid/mixin/server/ServerLoginMixin.java
@@ -7,6 +7,8 @@ import cn.alini.trueuuid.server.*;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPipeline;
 import net.minecraft.network.Connection;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
@@ -23,6 +25,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.util.UUID;
@@ -136,6 +139,13 @@ public abstract class ServerLoginMixin {
         }
     }
 
+    @Inject(method = "handleAcceptedLogin", at = @At("HEAD"), cancellable = true)
+    private void trueuuid$blockAcceptUntilAuthFinishes(CallbackInfo ci) {
+        if (this.trueuuid$txId != 0) {
+            ci.cancel();
+        }
+    }
+
     @Inject(method = "handleCustomQueryPacket", at = @At("HEAD"), cancellable = true)
     private void trueuuid$onLoginCustom(ServerboundCustomQueryPacket packet, CallbackInfo ci) {
         if (this.trueuuid$txId == 0) return;
@@ -226,7 +236,9 @@ public abstract class ServerLoginMixin {
                                     }
                                 }
                                 this.gameProfile = newProfile;
+                                reset();
                                 try {
+                                    trueuuid$removePipelineHandlerIfPresent("forge:forge_fixes");
                                     Method method = this.getClass().getDeclaredMethod("m_10055_");
                                     method.setAccessible(true);
                                     method.invoke(this);
@@ -303,6 +315,31 @@ public abstract class ServerLoginMixin {
             } catch (Throwable ignored) {}
             this.connection.disconnect(reason);
         }, "TrueUUID-AsyncDisconnect").start();
+    }
+
+    @Unique
+    private void trueuuid$removePipelineHandlerIfPresent(String name) {
+        try {
+            for (Field field : Connection.class.getDeclaredFields()) {
+                if (!Channel.class.isAssignableFrom(field.getType())) {
+                    continue;
+                }
+                field.setAccessible(true);
+                Channel channel = (Channel) field.get(this.connection);
+                if (channel == null) {
+                    return;
+                }
+                ChannelPipeline pipeline = channel.pipeline();
+                if (pipeline.get(name) != null) {
+                    pipeline.remove(name);
+                }
+                return;
+            }
+        } catch (Throwable t) {
+            if (TrueuuidConfig.debug()) {
+                System.out.println("[TrueUUID] 清理Netty处理器失败: " + t);
+            }
+        }
     }
 
     @Unique


### PR DESCRIPTION
## Summary
- bump mod version to 1.0.6
- block accepted login until TrueUUID authentication finishes
- reset login state and remove duplicate Forge pipeline handler before continuing accepted login

## Testing
- built local 1.20.1 jar previously for manual server testing