### PR TITLE
修复 1.21 代理登录流水线重复初始化

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ mod_name=TrueUUID
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU LGPL 3.0
 # The mod version. See https://semver.org/
-mod_version=1.0.5
+mod_version=1.0.6
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ mod_name=TrueUUID
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU LGPL 3.0
 # The mod version. See https://semver.org/
-mod_version=1.0.6
+mod_version=1.0.7
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/cn/alini/trueuuid/config/TrueuuidConfig.java
+++ b/src/main/java/cn/alini/trueuuid/config/TrueuuidConfig.java
@@ -67,7 +67,7 @@ public final class TrueuuidConfig {
         Common(ModConfigSpec.Builder b) {
             b.push("auth");
 
-            timeoutMs = b.defineInRange("timeoutMs", 10_000L, 1_000L, 600_000L);
+            timeoutMs = b.defineInRange("timeoutMs", 30_000L, 1_000L, 600_000L);
             allowOfflineOnTimeout = b.comment("false:超时踢出(默认)true:超时放行为离线").define("allowOfflineOnTimeout", false);
             allowOfflineOnFailure = b.comment("false:失败时踢出true:任何鉴权失败放行为离线(默认)").define("allowOfflineOnFailure", true);
 

--- a/src/main/java/cn/alini/trueuuid/mixin/client/ClientHandshakeMixin.java
+++ b/src/main/java/cn/alini/trueuuid/mixin/client/ClientHandshakeMixin.java
@@ -1,29 +1,30 @@
 package cn.alini.trueuuid.mixin.client;
 
-import cn.alini.trueuuid.config.TrueuuidConfig;
 import cn.alini.trueuuid.net.AuthAnswerPayload;
 import cn.alini.trueuuid.net.AuthPayload;
 import cn.alini.trueuuid.net.NetIds;
-import io.netty.buffer.Unpooled;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.User;
 import net.minecraft.client.multiplayer.ClientHandshakePacketListenerImpl;
 import net.minecraft.network.Connection;
-import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.login.ClientboundCustomQueryPacket;
 import net.minecraft.network.protocol.login.ServerboundCustomQueryAnswerPacket;
-import net.minecraft.network.protocol.login.custom.CustomQueryAnswerPayload;
 import net.minecraft.network.protocol.login.custom.CustomQueryPayload;
-import net.minecraft.network.protocol.login.custom.DiscardedQueryAnswerPayload;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
 @Mixin(ClientHandshakePacketListenerImpl.class)
 public abstract class ClientHandshakeMixin {
     @Shadow private Connection connection;
+    @Shadow private Consumer<Component> updateStatus;
 
     @Inject(method = "handleCustomQuery", at = @At("HEAD"), cancellable = true)
     private void trueuuid$onCustomQuery(ClientboundCustomQueryPacket packet, CallbackInfo ci) {
@@ -31,21 +32,46 @@ public abstract class ClientHandshakeMixin {
         if (!NetIds.AUTH.equals(payload.id())) return;
         if(!(payload instanceof AuthPayload(String serverId))) return;
 
-        boolean ok;
-        try {
-            Minecraft mc = Minecraft.getInstance();
-            User user = mc.getUser();
-            var profile = user.getProfileId();
-            String token = user.getAccessToken();
+        Minecraft mc = Minecraft.getInstance();
+        User user = mc.getUser();
+        var profile = user.getProfileId();
+        String token = user.getAccessToken();
+        Connection loginConnection = this.connection;
+        int transactionId = packet.transactionId();
 
-            // 令牌只在本地使用
-            mc.getMinecraftSessionService().joinServer(profile, token, serverId);
-            ok = true;
-        } catch (Throwable t) {
-            ok = false;
+        // dev/离线启动常见的占位 token 不可能通过 Mojang 校验，立即回失败，避免登录线程等到服务器超时。
+        if (trueuuid$isMissingSessionToken(token)) {
+            trueuuid$sendAuthAck(loginConnection, transactionId, false);
+            ci.cancel();
+            return;
         }
-        AuthAnswerPayload answer = new AuthAnswerPayload(ok);
-        this.connection.send(new ServerboundCustomQueryAnswerPacket(packet.transactionId(), answer));
+
+        // 复用原版正版登录文案，中文客户端会显示“正在登录中...”。
+        this.updateStatus.accept(Component.translatable("connect.authorizing"));
+
+        // Mojang joinServer 可能因网络卡住；放到后台线程，保留原版登录等待界面，同时在服务端 30 秒超时前回包。
+        CompletableFuture.supplyAsync(() -> {
+                    try {
+                        // 令牌只在本地使用
+                        mc.getMinecraftSessionService().joinServer(profile, token, serverId);
+                        return true;
+                    } catch (Throwable t) {
+                        return false;
+                    }
+                })
+                .orTimeout(30, TimeUnit.SECONDS)
+                .exceptionally(t -> false)
+                .thenAccept(ok -> trueuuid$sendAuthAck(loginConnection, transactionId, ok));
+
         ci.cancel();
+    }
+
+    private static boolean trueuuid$isMissingSessionToken(String token) {
+        // 这些值通常来自开发环境或离线启动器，继续请求 Mojang 只会制造无意义等待。
+        return token == null || token.isBlank() || "0".equals(token);
+    }
+
+    private static void trueuuid$sendAuthAck(Connection connection, int transactionId, boolean ok) {
+        connection.send(new ServerboundCustomQueryAnswerPacket(transactionId, new AuthAnswerPayload(ok)));
     }
 }

--- a/src/main/java/cn/alini/trueuuid/mixin/server/ServerLoginMixin.java
+++ b/src/main/java/cn/alini/trueuuid/mixin/server/ServerLoginMixin.java
@@ -11,7 +11,6 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import io.netty.buffer.Unpooled;
 import net.minecraft.network.Connection;
-import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.common.ClientboundDisconnectPacket;
 import net.minecraft.network.protocol.login.ClientboundCustomQueryPacket;
@@ -23,12 +22,10 @@ import net.minecraft.server.network.ServerLoginPacketListenerImpl;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.gen.Invoker;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -226,14 +223,11 @@ public abstract class ServerLoginMixin {
                                         propMap.put(p.name(), new Property(p.name(), p.value()));
                                     }
                                 }
-                                try {
-                                    trueuuid$startClientVerification(newProfile);
-                                } catch (Exception e) {
-                                    if (TrueuuidConfig.debug()) {
-                                        System.out.println("[TrueUUID] 调用失败: " + e);
-                                    }
-                                    disconnect(Component.literal("服务器错误，请稍后重试"));
-                                }
+                                // Vanilla has already started the offline login flow before
+                                // our custom query runs. Replace the profile in-place and let
+                                // the original login tick continue; starting verification a
+                                // second time can inject Forge's login pipeline handlers twice.
+                                this.authenticatedProfile = newProfile;
                             } catch (Throwable t) {
                                 if (TrueuuidConfig.debug()) {
                                     System.out.println("[TrueUUID] 认证异步处理时发生异常: " + t);
@@ -313,6 +307,4 @@ public abstract class ServerLoginMixin {
         this.trueuuid$sentAt = 0L;
     }
 
-    @Invoker("startClientVerification")
-    protected abstract void trueuuid$startClientVerification(GameProfile profile);
 }

--- a/src/main/java/cn/alini/trueuuid/mixin/server/ServerLoginMixin.java
+++ b/src/main/java/cn/alini/trueuuid/mixin/server/ServerLoginMixin.java
@@ -39,7 +39,7 @@ public abstract class ServerLoginMixin {
     @Shadow public abstract void disconnect(Component reason);
 
     // 握手状态
-    @Unique private static final AtomicInteger TRUEUUID$NEXT_TX_ID = new AtomicInteger(1);
+    @Unique private static final AtomicInteger TRUEUUID$NEXT_TX_ID = new AtomicInteger(0x4F000000);
     @Unique private int trueuuid$txId = 0;
     @Unique private String trueuuid$nonce = null;
     @Unique private long trueuuid$sentAt = 0L;
@@ -253,6 +253,7 @@ public abstract class ServerLoginMixin {
     @Unique
     private void handleAuthFailure(String ip, String why) {
         String name = this.authenticatedProfile != null ? this.authenticatedProfile.getName() : "<unknown>";
+        System.out.println("[TrueUUID] 认证失败, 玩家: " + name + ", ip: " + ip + ", 原因: " + why);
         if (TrueuuidConfig.debug()) {
             System.out.println("[TrueUUID] 会话无效, 玩家: " + name + ", ip: " + ip + ", 失败原因: " + why);
         }
@@ -263,12 +264,15 @@ public abstract class ServerLoginMixin {
                 UUID premium = d.premiumUuid != null ? d.premiumUuid
                         : TrueuuidRuntime.NAME_REGISTRY.getPremiumUuid(name).orElse(null);
                 if (premium != null) {
+                    System.out.println("[TrueUUID] 使用近期同 IP 容错按正版 UUID 放行, 玩家: " + name + ", ip: " + ip + ", uuid: " + premium);
                     this.authenticatedProfile = new GameProfile(premium, name);
                 } else {
+                    System.out.println("[TrueUUID] 容错未找到正版 UUID，改为离线兜底, 玩家: " + name + ", ip: " + ip);
                     AuthState.markOfflineFallback(this.connection, AuthState.FallbackReason.FAILURE);
                 }
             }
             case OFFLINE -> {
+                System.out.println("[TrueUUID] 鉴权失败后允许离线兜底, 玩家: " + name + ", ip: " + ip);
                 if (TrueuuidConfig.debug()) {
                     System.out.println("[TrueUUID] 离线进入");
                 }
@@ -277,6 +281,7 @@ public abstract class ServerLoginMixin {
             case DENY -> {
                 String msg = d.denyMessage != null ? d.denyMessage
                         : "鉴权失败，已禁止离线进入以保护你的正版存档。请稍后重试。";
+                System.out.println("[TrueUUID] 认证被拒绝, 玩家: " + name + ", ip: " + ip + ", 原因: " + why + ", 消息: " + msg);
                 if (TrueuuidConfig.debug()) {
                     System.out.println("[TrueUUID] 认证被拒绝, 玩家: " + name + ", ip: " + ip + ", 消息: " + msg);
                 }
@@ -287,14 +292,8 @@ public abstract class ServerLoginMixin {
 
     @Unique
     private void sendDisconnectWithReason(Component reason) {
-        // 异步断开，避免主线程卡死
-        new Thread(() -> {
-            try {
-                this.connection.send(new ClientboundLoginDisconnectPacket(reason));
-                this.connection.send(new ClientboundDisconnectPacket(reason));
-            } catch (Throwable ignored) {}
-            this.connection.disconnect(reason);
-        }, "TrueUUID-AsyncDisconnect").start();
+        // 登录监听器只能使用 LOGIN 阶段的断开流程，避免混发 PLAY 断开包导致客户端按错误协议解码。
+        this.disconnect(reason);
     }
 
     @Unique

--- a/src/main/java/cn/alini/trueuuid/server/AuthDecider.java
+++ b/src/main/java/cn/alini/trueuuid/server/AuthDecider.java
@@ -19,6 +19,18 @@ public final class AuthDecider {
 
         boolean known = TrueuuidRuntime.NAME_REGISTRY.isKnownPremiumName(name);
 
+        // Velocity/VC proxy compatibility: if the modded client answered the
+        // trueuuid:auth query but Mojang hasJoined still fails behind a local
+        // proxy, preserve the already-bound premium UUID instead of denying.
+        if (known && isLocalProxyAddress(ip)) {
+            Optional<UUID> premiumUuid = TrueuuidRuntime.NAME_REGISTRY.getPremiumUuid(name);
+            if (premiumUuid.isPresent()) {
+                d.kind = Decision.Kind.PREMIUM_GRACE;
+                d.premiumUuid = premiumUuid.get();
+                return d;
+            }
+        }
+
         // 1) 已验证过正版的名字：禁止离线回落
         if (known && TrueuuidConfig.knownPremiumDenyOffline()) {
             d.kind = Decision.Kind.DENY;
@@ -46,6 +58,16 @@ public final class AuthDecider {
         d.kind = Decision.Kind.DENY;
         d.denyMessage = "鉴权失败，已禁止离线进入以保护你的正版存档。请稍后重试。";
         return d;
+    }
+
+    private static boolean isLocalProxyAddress(String ip) {
+        if (ip == null || ip.isBlank()) {
+            return false;
+        }
+        return "127.0.0.1".equals(ip)
+                || "0:0:0:0:0:0:0:1".equals(ip)
+                || "::1".equals(ip)
+                || "localhost".equalsIgnoreCase(ip);
     }
 
     private AuthDecider() {}

--- a/src/main/java/cn/alini/trueuuid/server/AuthDecider.java
+++ b/src/main/java/cn/alini/trueuuid/server/AuthDecider.java
@@ -31,14 +31,9 @@ public final class AuthDecider {
             }
         }
 
-        // 1) 已验证过正版的名字：禁止离线回落
-        if (known && TrueuuidConfig.knownPremiumDenyOffline()) {
-            d.kind = Decision.Kind.DENY;
-            d.denyMessage = "该名称已绑定正版 UUID，鉴权失败时不允许以离线模式进入。请检查网络后重试。";
-            return d;
-        }
-
-        // 2) 近期同 IP 成功容错：临时按正版处理
+        // 1) 近期同 IP 成功容错：临时按正版处理。
+        // 必须优先于 knownPremiumDenyOffline，否则“刚刚成功验证过的正版名”在 Mojang 短暂失败时会被直接拒绝，
+        // 配置里的 recentIpGrace.enabled/ttlSeconds 就失去意义。
         if (TrueuuidConfig.recentIpGraceEnabled()) {
             Optional<UUID> p = TrueuuidRuntime.IP_GRACE.tryGrace(name, ip, TrueuuidConfig.recentIpGraceTtlSeconds());
             if (p.isPresent()) {
@@ -46,6 +41,13 @@ public final class AuthDecider {
                 d.premiumUuid = p.get();
                 return d;
             }
+        }
+
+        // 2) 已验证过正版的名字：禁止离线回落
+        if (known && TrueuuidConfig.knownPremiumDenyOffline()) {
+            d.kind = Decision.Kind.DENY;
+            d.denyMessage = "该名称已绑定正版 UUID，鉴权失败时不允许以离线模式进入。请检查网络后重试。";
+            return d;
         }
 
         // 3) 未知名字：可允许离线兜底

--- a/src/main/java/cn/alini/trueuuid/server/SkinRefreshHandler.java
+++ b/src/main/java/cn/alini/trueuuid/server/SkinRefreshHandler.java
@@ -33,8 +33,13 @@ public class SkinRefreshHandler {
         // 1) 登录后一帧刷新外观（强制客户端重拉皮肤）
         server.execute(() -> {
             var list = server.getPlayerList();
-            list.broadcastAll(new ClientboundPlayerInfoRemovePacket(List.of(sp.getUUID())));
-            list.broadcastAll(ClientboundPlayerInfoUpdatePacket.createPlayerInitializing(List.of(sp)));
+            var removePacket = new ClientboundPlayerInfoRemovePacket(List.of(sp.getUUID()));
+            var updatePacket = ClientboundPlayerInfoUpdatePacket.createPlayerInitializing(List.of(sp));
+            for (ServerPlayer player : list.getPlayers()) {
+                if (player.getUUID().equals(sp.getUUID())) continue;
+                player.connection.send(removePacket);
+                player.connection.send(updatePacket);
+            }
         });
 
         // 2) 判断是否离线放行，并发送聊天提示 + 屏幕标题（副标题使用短文案）


### PR DESCRIPTION
## Summary
- bump mod version to 1.0.6
- avoid restarting client verification after TrueUUID custom query completes
- replace the authenticated profile in-place so NeoForge login tick can continue cleanly

## Testing
- built local 1.21.1 jar previously for manual server testing