### PR TITLE
修复 NeoForge 1.21 登录鉴权超时与容错，增加对authlib-injector协议的皮肤站支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Note: Client and server must both install this mod. The server must run in offli
 - Policy: allowOfflineForUnknownOnly
     - Only allow offline fallback for names that have never verified as premium.
 - Recent IP Grace (optional)
-    - If the same name and IP had a successful verification within a short TTL (e.g., 5 minutes), a temporary premium session can be granted if verification fails. Useful to handle transient network hiccups. Use with caution on shared IP environments.
+    - After a player has already verified successfully and then disconnects, the same name and IP may reuse that verified UUID only within a short logout window (default: 10 seconds) if the next verification fails. This is intended for immediate reconnects only and is consumed after one use.
 - Admin command: /trueuuid link <name>
     - Migrate/merge an offline UUID’s data to the premium UUID. Supports dry-run and backups.
 - Reliable disconnect reason on 1.20.x Forge
@@ -85,12 +85,14 @@ Keys and defaults:
 - auth.allowOfflineForUnknownOnly = true
     - Only names that have never verified as premium may fall back to offline.
 - auth.recentIpGrace.enabled = true
-    - Enable recent-IP grace window.
-- auth.recentIpGrace.ttlSeconds = 300
-    - TTL for recent-IP grace (suggested 60–600).
+    - Enable same-IP short reconnect grace after a verified player disconnects.
+- auth.recentIpGrace.ttlSeconds = 10
+    - Seconds after logout during which the same name and IP may reuse the last verified UUID. Valid range: 1–60. The grace entry is consumed after one use.
+- auth.yggdrasil.apiRootWhitelist = []
+    - Optional authlib-injector/Yggdrasil skin-site URL whitelist. Empty means trust the client-reported skin-site `hasJoined` endpoint. Add entries such as `["littleskin.cn"]` to only accept matching endpoints.
 
 Notes:
-- Recent IP Grace is a usability feature, not strong security. Do not use a large TTL. Avoid enabling on shared networks if you have strict identity requirements.
+- Recent IP Grace is a usability feature, not strong security. Keep the logout window short and avoid enabling it on shared networks if you have strict identity requirements.
 - The legacy `allowOfflineOnFailure` is still respected, but the new policies are recommended.
 
 ## Commands

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -28,7 +28,7 @@ TrueUUID 让离线服也能：
 - 策略：allowOfflineForUnknownOnly
     - 仅允许“从未验证为正版”的新名字走离线兜底。
 - 近期同 IP 容错（可选）
-    - 若同名同 IP 在短时间 TTL 内曾验证成功，这次失败可临时按正版处理，用于缓解瞬时网络问题。公共/共享网络请谨慎启用，并缩短 TTL。
+    - 玩家已经成功完成正版/皮肤站校验并退出后，仅在同名同 IP 的短时间重连窗口内（默认 10 秒）允许复用上次验证 UUID；命中一次后即消费。用于处理刚掉线立刻重连，不再从“验证成功时间”开始按分钟计时。
 - 管理员命令：/trueuuid link <name>
     - 将该名字对应“离线 UUID”的玩家数据迁移/合并到“正版 UUID”。支持 dry-run 预览与备份。
 - 可靠显示踢出原因（Forge 1.20.x）
@@ -85,12 +85,14 @@ TrueUUID 让离线服也能：
 - auth.allowOfflineForUnknownOnly = true
     - 仅“从未验证为正版”的名字可离线兜底。
 - auth.recentIpGrace.enabled = true
-    - 启用“近期同 IP 成功”容错。
-- auth.recentIpGrace.ttlSeconds = 300
-    - 同 IP 容错 TTL（建议 60–600）。
+    - 启用“退出后同 IP 短时重连”容错。
+- auth.recentIpGrace.ttlSeconds = 10
+    - 玩家退出后允许同名同 IP 复用上次验证 UUID 的秒数。有效范围：1–60。命中一次后即消费。
+- auth.yggdrasil.apiRootWhitelist = []
+    - authlib-injector/Yggdrasil 皮肤站 hasJoined URL 白名单。留空表示信任客户端上报的皮肤站端点；可填如 `["littleskin.cn"]`，只允许匹配的皮肤站通过。
 
 说明：
-- 同 IP 容错重在可用性，并非强安全；TTL 不宜过长，公共网络慎用。
+- 同 IP 容错重在可用性，并非强安全；请保持退出重连窗口很短，公共/共享网络慎用。
 - 旧开关 `allowOfflineOnFailure` 仍有效，但建议优先使用新策略。
 
 ## 管理命令

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ mod_name=TrueUUID
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU LGPL 3.0
 # The mod version. See https://semver.org/
-mod_version=1.0.5
+mod_version=1.0.6
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ mod_name=TrueUUID
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU LGPL 3.0
 # The mod version. See https://semver.org/
-mod_version=1.0.7
+mod_version=1.0.8
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ mod_name=TrueUUID
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU LGPL 3.0
 # The mod version. See https://semver.org/
-mod_version=1.0.6
+mod_version=1.0.7
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/cn/alini/trueuuid/config/TrueuuidConfig.java
+++ b/src/main/java/cn/alini/trueuuid/config/TrueuuidConfig.java
@@ -5,6 +5,8 @@ import net.neoforged.fml.ModLoadingContext;
 import net.neoforged.fml.config.ModConfig;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
+import java.util.List;
+
 public final class TrueuuidConfig {
     public static final ModConfigSpec COMMON_SPEC;
     public static final Common COMMON;
@@ -41,6 +43,8 @@ public final class TrueuuidConfig {
     // 新增 nomojang 开关访问器
     public static boolean nomojangEnabled() { return COMMON.nomojangEnabled.get(); }
     public static String mojangReverseProxy() { return COMMON.mojangReverseProxy.get(); }
+    @SuppressWarnings("unchecked")
+    public static List<String> apiRootWhitelist() { return (List<String>) COMMON.apiRootWhitelist.get(); }
 
     public static final class Common {
         public final ModConfigSpec.LongValue timeoutMs;
@@ -56,6 +60,7 @@ public final class TrueuuidConfig {
         // 新增 nomojang 配置
         public final ModConfigSpec.BooleanValue nomojangEnabled;
         public final ModConfigSpec.ConfigValue<String> mojangReverseProxy;
+        public final ModConfigSpec.ConfigValue<List<? extends String>> apiRootWhitelist;
 
         // 新增：策略相关
         public final ModConfigSpec.BooleanValue knownPremiumDenyOffline;
@@ -86,15 +91,20 @@ public final class TrueuuidConfig {
                     .define("knownPremiumDenyOffline", true);
             allowOfflineForUnknownOnly = b.comment("仅对从未验证为正版的新名字允许离线兜底。")
                     .define("allowOfflineForUnknownOnly", true);
-            recentIpGraceEnabled      = b.comment("启用“近期同 IP 成功”容错，在 TTL 内失败时临时按正版处理。")
+            recentIpGraceEnabled      = b.comment("启用“退出后同 IP 短时重连”容错，只在玩家退出后的 TTL 秒内临时沿用上次认证来源。")
                     .define("recentIpGrace.enabled", true);
-            recentIpGraceTtlSeconds   = b.comment("“近期同 IP 成功”容错的 TTL 秒数。建议 60~600。")
-                    .defineInRange("recentIpGrace.ttlSeconds", 300, 30, 3600);
+            recentIpGraceTtlSeconds   = b.comment("退出游戏后允许同 IP 容错重连的秒数。默认 10 秒，避免长期误导为皮肤站/正版登录。")
+                    .defineInRange("recentIpGrace.ttlSeconds", 10, 1, 60);
             debug = b.comment("启用调试日志输出").define("debug", false);
             // 新增：跳过 Mojang 会话认证（开启后不再通过 sessionserver 验证）
             nomojangEnabled = b.comment("开启后关闭对 Mojang 会话服务的在线校验逻辑；同 IP 且近期有正版成功的名称按正版 UUID 处理，其余直接按离线进入处理。")
                     .define("nomojang.enabled", false);
             mojangReverseProxy = b.comment("mojang的反代地址,专门为那些不想给服务器开代理的人使用,默认为mojang地址").define("mojangReverseProxy", "https://sessionserver.mojang.com");
+            apiRootWhitelist = b.comment(
+                            "authlib-injector/Yggdrasil 皮肤站 hasJoined URL 白名单。",
+                            "默认空列表表示信任客户端上报的皮肤站端点；填写 littleskin.cn 等关键字后，只允许匹配项通过。"
+                    )
+                    .defineListAllowEmpty(List.of("yggdrasil.apiRootWhitelist"), List::of, o -> o instanceof String);
             b.pop();
         }
     }

--- a/src/main/java/cn/alini/trueuuid/config/TrueuuidConfig.java
+++ b/src/main/java/cn/alini/trueuuid/config/TrueuuidConfig.java
@@ -67,7 +67,7 @@ public final class TrueuuidConfig {
         Common(ModConfigSpec.Builder b) {
             b.push("auth");
 
-            timeoutMs = b.defineInRange("timeoutMs", 10_000L, 1_000L, 600_000L);
+            timeoutMs = b.defineInRange("timeoutMs", 30_000L, 1_000L, 600_000L);
             allowOfflineOnTimeout = b.comment("false:超时踢出(默认)true:超时放行为离线").define("allowOfflineOnTimeout", false);
             allowOfflineOnFailure = b.comment("false:失败时踢出true:任何鉴权失败放行为离线(默认)").define("allowOfflineOnFailure", true);
 

--- a/src/main/java/cn/alini/trueuuid/mixin/client/ClientHandshakeMixin.java
+++ b/src/main/java/cn/alini/trueuuid/mixin/client/ClientHandshakeMixin.java
@@ -13,10 +13,15 @@ import net.minecraft.network.protocol.login.ServerboundCustomQueryAnswerPacket;
 import net.minecraft.network.protocol.login.custom.CustomQueryPayload;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -41,10 +46,13 @@ public abstract class ClientHandshakeMixin {
 
         // dev/离线启动常见的占位 token 不可能通过 Mojang 校验，立即回失败，避免登录线程等到服务器超时。
         if (trueuuid$isMissingSessionToken(token)) {
-            trueuuid$sendAuthAck(loginConnection, transactionId, false);
+            trueuuid$sendAuthAck(loginConnection, transactionId, false, "");
             ci.cancel();
             return;
         }
+
+        // 在调用 joinServer 之前先读取 hasJoined URL，authlib-injector 会影响该端点。
+        String hasJoinedUrl = trueuuid$resolveHasJoinedUrl();
 
         // 复用原版正版登录文案，中文客户端会显示“正在登录中...”。
         this.updateStatus.accept(Component.translatable("connect.authorizing"));
@@ -61,17 +69,133 @@ public abstract class ClientHandshakeMixin {
                 })
                 .orTimeout(30, TimeUnit.SECONDS)
                 .exceptionally(t -> false)
-                .thenAccept(ok -> trueuuid$sendAuthAck(loginConnection, transactionId, ok));
+                .thenAccept(ok -> trueuuid$sendAuthAck(loginConnection, transactionId, ok, hasJoinedUrl));
 
         ci.cancel();
     }
 
+    @Unique
     private static boolean trueuuid$isMissingSessionToken(String token) {
         // 这些值通常来自开发环境或离线启动器，继续请求 Mojang 只会制造无意义等待。
         return token == null || token.isBlank() || "0".equals(token);
     }
 
-    private static void trueuuid$sendAuthAck(Connection connection, int transactionId, boolean ok) {
-        connection.send(new ServerboundCustomQueryAnswerPacket(transactionId, new AuthAnswerPayload(ok)));
+    @Unique
+    private static void trueuuid$sendAuthAck(Connection connection, int transactionId, boolean ok, String hasJoinedUrl) {
+        connection.send(new ServerboundCustomQueryAnswerPacket(transactionId, new AuthAnswerPayload(ok, hasJoinedUrl)));
+    }
+
+    /**
+     * 解析客户端实际使用的 hasJoined 端点。
+     * authlib-injector 通常通过 -javaagent:authlib-injector.jar=<API root> 注入，优先读取该参数，
+     * 避免把客户端本机 127.0.0.1 代理地址发给服务端。
+     */
+    @Unique
+    private static String trueuuid$resolveHasJoinedUrl() {
+        String agentUrl = trueuuid$resolveHasJoinedUrlFromJavaAgent();
+        if (!agentUrl.isEmpty()) return agentUrl;
+
+        try {
+            Class<?> clazz = Class.forName("com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService");
+
+            String url = trueuuid$readStaticUrlField(clazz, "CHECK_URL");
+            if (url != null) return trueuuid$sanitizeUrl(url);
+
+            for (Field f : clazz.getDeclaredFields()) {
+                if (java.lang.reflect.Modifier.isStatic(f.getModifiers()) && URL.class.isAssignableFrom(f.getType())) {
+                    f.setAccessible(true);
+                    URL fieldVal = (URL) f.get(null);
+                    if (fieldVal != null && fieldVal.toString().contains("hasJoined")) {
+                        return trueuuid$sanitizeUrl(fieldVal.toString());
+                    }
+                }
+            }
+
+            for (Field f : clazz.getDeclaredFields()) {
+                if (java.lang.reflect.Modifier.isStatic(f.getModifiers()) && String.class.isAssignableFrom(f.getType())) {
+                    f.setAccessible(true);
+                    Object val = f.get(null);
+                    if (val instanceof String s && s.contains("hasJoined")) {
+                        return trueuuid$sanitizeUrl(s);
+                    }
+                }
+            }
+        } catch (Throwable ignored) {
+            // 反射失败时使用 Mojang 默认端点。
+        }
+        return "";
+    }
+
+    @Unique
+    private static String trueuuid$resolveHasJoinedUrlFromJavaAgent() {
+        try {
+            List<String> args = ManagementFactory.getRuntimeMXBean().getInputArguments();
+            for (String arg : args) {
+                if (!arg.startsWith("-javaagent:")) continue;
+                String lower = arg.toLowerCase(java.util.Locale.ROOT);
+                if (!lower.contains("authlib")) continue;
+
+                int equals = arg.indexOf('=');
+                if (equals < 0 || equals + 1 >= arg.length()) continue;
+
+                String apiRoot = arg.substring(equals + 1).trim();
+                String hasJoined = trueuuid$buildHasJoinedUrlFromApiRoot(apiRoot);
+                if (!hasJoined.isEmpty()) return hasJoined;
+            }
+        } catch (Throwable ignored) {
+            // 无法读取 JVM 参数时回退到 CHECK_URL 反射。
+        }
+        return "";
+    }
+
+    @Unique
+    private static String trueuuid$buildHasJoinedUrlFromApiRoot(String apiRoot) {
+        if (apiRoot == null || apiRoot.isBlank()) return "";
+        String root = apiRoot.trim();
+        if (!root.endsWith("/")) {
+            root = root + "/";
+        }
+        return trueuuid$sanitizeUrl(root + "sessionserver/session/minecraft/hasJoined");
+    }
+
+    @Unique
+    private static String trueuuid$readStaticUrlField(Class<?> clazz, String fieldName) {
+        try {
+            Field f = clazz.getDeclaredField(fieldName);
+            f.setAccessible(true);
+            Object val = f.get(null);
+            if (val instanceof URL u) return u.toString();
+            if (val instanceof String s) return s;
+        } catch (Throwable ignored) {}
+        return null;
+    }
+
+    @Unique
+    private static String trueuuid$sanitizeUrl(String rawUrl) {
+        if (rawUrl == null || rawUrl.isEmpty()) return "";
+
+        String url = rawUrl;
+        if (url.startsWith("http://127.0.0.1") || url.startsWith("http://localhost")) {
+            int schemeIdx = url.indexOf("/https/");
+            if (schemeIdx >= 0) {
+                url = "https://" + url.substring(schemeIdx + "/https/".length());
+            } else {
+                int httpIdx = url.indexOf("/http/");
+                if (httpIdx >= 0) {
+                    url = "http://" + url.substring(httpIdx + "/http/".length());
+                }
+            }
+        }
+
+        if (url.contains("sessionserver.mojang.com")) {
+            return "";
+        }
+
+        int qIdx = url.indexOf('?');
+        if (qIdx >= 0) {
+            url = url.substring(0, qIdx);
+        }
+
+        return url;
     }
 }

--- a/src/main/java/cn/alini/trueuuid/mixin/client/ClientHandshakeMixin.java
+++ b/src/main/java/cn/alini/trueuuid/mixin/client/ClientHandshakeMixin.java
@@ -1,29 +1,30 @@
 package cn.alini.trueuuid.mixin.client;
 
-import cn.alini.trueuuid.config.TrueuuidConfig;
 import cn.alini.trueuuid.net.AuthAnswerPayload;
 import cn.alini.trueuuid.net.AuthPayload;
 import cn.alini.trueuuid.net.NetIds;
-import io.netty.buffer.Unpooled;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.User;
 import net.minecraft.client.multiplayer.ClientHandshakePacketListenerImpl;
 import net.minecraft.network.Connection;
-import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.login.ClientboundCustomQueryPacket;
 import net.minecraft.network.protocol.login.ServerboundCustomQueryAnswerPacket;
-import net.minecraft.network.protocol.login.custom.CustomQueryAnswerPayload;
 import net.minecraft.network.protocol.login.custom.CustomQueryPayload;
-import net.minecraft.network.protocol.login.custom.DiscardedQueryAnswerPayload;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
 @Mixin(ClientHandshakePacketListenerImpl.class)
 public abstract class ClientHandshakeMixin {
     @Shadow private Connection connection;
+    @Shadow private Consumer<Component> updateStatus;
 
     @Inject(method = "handleCustomQuery", at = @At("HEAD"), cancellable = true)
     private void trueuuid$onCustomQuery(ClientboundCustomQueryPacket packet, CallbackInfo ci) {
@@ -31,21 +32,46 @@ public abstract class ClientHandshakeMixin {
         if (!NetIds.AUTH.equals(payload.id())) return;
         if(!(payload instanceof AuthPayload(String serverId))) return;
 
-        boolean ok;
-        try {
-            Minecraft mc = Minecraft.getInstance();
-            User user = mc.getUser();
-            var profile = user.getProfileId();
-            String token = user.getAccessToken();
+        Minecraft mc = Minecraft.getInstance();
+        User user = mc.getUser();
+        var profile = user.getProfileId();
+        String token = user.getAccessToken();
+        Connection loginConnection = this.connection;
+        int transactionId = packet.transactionId();
 
-            // 令牌只在本地使用
-            mc.getMinecraftSessionService().joinServer(profile, token, serverId);
-            ok = true;
-        } catch (Throwable t) {
-            ok = false;
+        // dev/离线启动常见的占位 token 不可能通过 Mojang 校验，立即回失败，避免登录线程等到服务器超时。
+        if (trueuuid$isMissingSessionToken(token)) {
+            trueuuid$sendAuthAck(loginConnection, transactionId, false);
+            ci.cancel();
+            return;
         }
-        AuthAnswerPayload answer = new AuthAnswerPayload(ok);
-        this.connection.send(new ServerboundCustomQueryAnswerPacket(packet.transactionId(), answer));
+
+        // 复用原版正版登录文案，中文客户端会显示“正在登录中...”。
+        this.updateStatus.accept(Component.translatable("connect.authorizing"));
+
+        // Mojang joinServer 可能因网络卡住；放到后台线程，保留原版登录等待界面，同时在服务端 30 秒超时前回包。
+        CompletableFuture.supplyAsync(() -> {
+                    try {
+                        // 令牌只在本地使用
+                        mc.getMinecraftSessionService().joinServer(profile, token, serverId);
+                        return true;
+                    } catch (Throwable t) {
+                        return false;
+                    }
+                })
+                .orTimeout(30, TimeUnit.SECONDS)
+                .exceptionally(t -> false)
+                .thenAccept(ok -> trueuuid$sendAuthAck(loginConnection, transactionId, ok));
+
         ci.cancel();
+    }
+
+    private static boolean trueuuid$isMissingSessionToken(String token) {
+        // 这些值通常来自开发环境或离线启动器，继续请求 Mojang 只会制造无意义等待。
+        return token == null || token.isBlank() || "0".equals(token);
+    }
+
+    private static void trueuuid$sendAuthAck(Connection connection, int transactionId, boolean ok) {
+        connection.send(new ServerboundCustomQueryAnswerPacket(transactionId, new AuthAnswerPayload(ok)));
     }
 }

--- a/src/main/java/cn/alini/trueuuid/mixin/server/ServerLoginMixin.java
+++ b/src/main/java/cn/alini/trueuuid/mixin/server/ServerLoginMixin.java
@@ -11,7 +11,6 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import io.netty.buffer.Unpooled;
 import net.minecraft.network.Connection;
-import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.common.ClientboundDisconnectPacket;
 import net.minecraft.network.protocol.login.ClientboundCustomQueryPacket;
@@ -23,12 +22,10 @@ import net.minecraft.server.network.ServerLoginPacketListenerImpl;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.gen.Invoker;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -226,14 +223,11 @@ public abstract class ServerLoginMixin {
                                         propMap.put(p.name(), new Property(p.name(), p.value()));
                                     }
                                 }
-                                try {
-                                    trueuuid$startClientVerification(newProfile);
-                                } catch (Exception e) {
-                                    if (TrueuuidConfig.debug()) {
-                                        System.out.println("[TrueUUID] 调用失败: " + e);
-                                    }
-                                    disconnect(Component.literal("服务器错误，请稍后重试"));
-                                }
+                                // Vanilla has already started the offline login flow before
+                                // our custom query runs. Replace the profile in-place and let
+                                // the original login tick continue; starting verification a
+                                // second time can inject Forge's login pipeline handlers twice.
+                                this.authenticatedProfile = newProfile;
                             } catch (Throwable t) {
                                 if (TrueuuidConfig.debug()) {
                                     System.out.println("[TrueUUID] 认证异步处理时发生异常: " + t);
@@ -313,6 +307,4 @@ public abstract class ServerLoginMixin {
         this.trueuuid$sentAt = 0L;
     }
 
-    @Invoker("startClientVerification")
-    protected abstract void trueuuid$startClientVerification(GameProfile profile);
 }

--- a/src/main/java/cn/alini/trueuuid/mixin/server/ServerLoginMixin.java
+++ b/src/main/java/cn/alini/trueuuid/mixin/server/ServerLoginMixin.java
@@ -39,7 +39,7 @@ public abstract class ServerLoginMixin {
     @Shadow public abstract void disconnect(Component reason);
 
     // 握手状态
-    @Unique private static final AtomicInteger TRUEUUID$NEXT_TX_ID = new AtomicInteger(1);
+    @Unique private static final AtomicInteger TRUEUUID$NEXT_TX_ID = new AtomicInteger(0x4F000000);
     @Unique private int trueuuid$txId = 0;
     @Unique private String trueuuid$nonce = null;
     @Unique private long trueuuid$sentAt = 0L;
@@ -253,6 +253,7 @@ public abstract class ServerLoginMixin {
     @Unique
     private void handleAuthFailure(String ip, String why) {
         String name = this.authenticatedProfile != null ? this.authenticatedProfile.getName() : "<unknown>";
+        System.out.println("[TrueUUID] 认证失败, 玩家: " + name + ", ip: " + ip + ", 原因: " + why);
         if (TrueuuidConfig.debug()) {
             System.out.println("[TrueUUID] 会话无效, 玩家: " + name + ", ip: " + ip + ", 失败原因: " + why);
         }
@@ -263,12 +264,15 @@ public abstract class ServerLoginMixin {
                 UUID premium = d.premiumUuid != null ? d.premiumUuid
                         : TrueuuidRuntime.NAME_REGISTRY.getPremiumUuid(name).orElse(null);
                 if (premium != null) {
+                    System.out.println("[TrueUUID] 使用近期同 IP 容错按正版 UUID 放行, 玩家: " + name + ", ip: " + ip + ", uuid: " + premium);
                     this.authenticatedProfile = new GameProfile(premium, name);
                 } else {
+                    System.out.println("[TrueUUID] 容错未找到正版 UUID，改为离线兜底, 玩家: " + name + ", ip: " + ip);
                     AuthState.markOfflineFallback(this.connection, AuthState.FallbackReason.FAILURE);
                 }
             }
             case OFFLINE -> {
+                System.out.println("[TrueUUID] 鉴权失败后允许离线兜底, 玩家: " + name + ", ip: " + ip);
                 if (TrueuuidConfig.debug()) {
                     System.out.println("[TrueUUID] 离线进入");
                 }
@@ -277,6 +281,7 @@ public abstract class ServerLoginMixin {
             case DENY -> {
                 String msg = d.denyMessage != null ? d.denyMessage
                         : "鉴权失败，已禁止离线进入以保护你的正版存档。请稍后重试。";
+                System.out.println("[TrueUUID] 认证被拒绝, 玩家: " + name + ", ip: " + ip + ", 原因: " + why + ", 消息: " + msg);
                 if (TrueuuidConfig.debug()) {
                     System.out.println("[TrueUUID] 认证被拒绝, 玩家: " + name + ", ip: " + ip + ", 消息: " + msg);
                 }
@@ -287,14 +292,8 @@ public abstract class ServerLoginMixin {
 
     @Unique
     private void sendDisconnectWithReason(Component reason) {
-        // 异步断开，避免主线程卡死
-        new Thread(() -> {
-            try {
-                this.connection.send(new ClientboundLoginDisconnectPacket(reason));
-                this.connection.send(new ClientboundDisconnectPacket(reason));
-            } catch (Throwable ignored) {}
-            this.connection.disconnect(reason);
-        }, "TrueUUID-AsyncDisconnect").start();
+        // 登录监听器只能使用 LOGIN 阶段的断开流程，避免混发 PLAY 断开包导致客户端按错误协议解码。
+        this.disconnect(reason);
     }
 
     @Unique

--- a/src/main/java/cn/alini/trueuuid/mixin/server/ServerLoginMixin.java
+++ b/src/main/java/cn/alini/trueuuid/mixin/server/ServerLoginMixin.java
@@ -27,6 +27,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -67,18 +68,21 @@ public abstract class ServerLoginMixin {
 
             // 尝试同 IP 的近期容错命中 -> 视为正版
             if (TrueuuidConfig.recentIpGraceEnabled() && ip != null) {
-                var pOpt = TrueuuidRuntime.IP_GRACE.tryGrace(name, ip, TrueuuidConfig.recentIpGraceTtlSeconds());
+                var pOpt = TrueuuidRuntime.IP_GRACE.tryGraceResult(name, ip, TrueuuidConfig.recentIpGraceTtlSeconds());
                 if (pOpt.isPresent()) {
-                    UUID premium = pOpt.get();
+                    UUID premium = pOpt.get().premiumUuid();
                     if (premium != null) {
                         if (TrueuuidConfig.debug()) {
                             System.out.println("[TrueUUID] nomojang: 找到同IP正版记录，按正版处理, uuid=" + premium);
                         }
                         GameProfile newProfile = new GameProfile(premium, name);
                         this.authenticatedProfile = newProfile;
+                        AuthState.AuthSource source = pOpt.get().source() == AuthState.AuthSource.YGGDRASIL
+                                ? AuthState.AuthSource.YGGDRASIL
+                                : AuthState.AuthSource.MOJANG;
+                        AuthState.markAuthSuccess(this.connection, source, pOpt.get().displayName());
                         // 记录成功（保持注册表/缓存一致）
-                        TrueuuidRuntime.NAME_REGISTRY.recordSuccess(name, premium, ip);
-                        TrueuuidRuntime.IP_GRACE.record(name, ip, premium);
+                        TrueuuidRuntime.NAME_REGISTRY.recordSuccess(name, premium, ip, source, pOpt.get().displayName());
                         return; // 直接返回，按正版处理完毕
                     }
                 }
@@ -163,12 +167,37 @@ public abstract class ServerLoginMixin {
         }
 
         boolean ackOk =  payload.ok();
+        String clientHasJoinedUrl = payload.hasJoinedUrl() == null ? "" : payload.hasJoinedUrl().trim();
+        if (TrueuuidConfig.debug()) {
+            System.out.println("[TrueUUID] 客户端认证包ackOk: " + ackOk + ", hasJoinedUrl: " + (clientHasJoinedUrl.isEmpty() ? "(mojang default)" : clientHasJoinedUrl));
+        }
         if (!ackOk) {
             if (TrueuuidConfig.debug()) {
                 System.out.println("[TrueUUID] 认证失败, 玩家: " + (this.authenticatedProfile != null ? this.authenticatedProfile.getName() : "<unknown>") + ", ip: " + ip + ", 原因: 客户端拒绝");
             }
             handleAuthFailure(ip, "客户端拒绝");
             reset(); ci.cancel(); return;
+        }
+
+        // 白名单校验：如果配置了白名单且客户端上报了非默认 URL，检查 URL 是否匹配任一配置项。
+        if (!clientHasJoinedUrl.isEmpty()) {
+            var whitelist = TrueuuidConfig.apiRootWhitelist();
+            if (!whitelist.isEmpty()) {
+                boolean allowed = false;
+                for (String entry : whitelist) {
+                    if (entry != null && !entry.isBlank() && clientHasJoinedUrl.contains(entry)) {
+                        allowed = true;
+                        break;
+                    }
+                }
+                if (!allowed) {
+                    if (TrueuuidConfig.debug()) {
+                        System.out.println("[TrueUUID] 客户端上报的 hasJoined URL 不在白名单中: " + clientHasJoinedUrl);
+                    }
+                    handleAuthFailure(ip, "不受信任的认证服务器");
+                    reset(); ci.cancel(); return;
+                }
+            }
         }
 
         // 幂等保护：如果已经处理过本次握手的 ack，则忽略重复包
@@ -182,11 +211,12 @@ public abstract class ServerLoginMixin {
         this.trueuuid$ackHandled = true;
 
         // 关键：使用异步 API，不在主线程阻塞
+        final String hasJoinedUrl = clientHasJoinedUrl;
         try {
             // 立即取消原始调用（以免继续执行原有逻辑），但不要 reset()，保留状态直到回调完成
             ci.cancel();
 
-            SessionCheck.hasJoinedAsync(this.authenticatedProfile.getName(), this.trueuuid$nonce, ip)
+            SessionCheck.hasJoinedAsync(this.authenticatedProfile.getName(), this.trueuuid$nonce, ip, hasJoinedUrl)
                     .whenComplete((resOpt, throwable) -> {
                         // 始终在主线程处理后续逻辑
                         server.execute(() -> {
@@ -210,8 +240,13 @@ public abstract class ServerLoginMixin {
                                 var res = resOpt.get();
 
                                 // 成功：记录注册表/近期 IP；替换为正版 UUID + 名称大小写矫正 + 注入皮肤
-                                TrueuuidRuntime.NAME_REGISTRY.recordSuccess(res.name(), res.uuid(), ip);
-                                TrueuuidRuntime.IP_GRACE.record(res.name(), ip, res.uuid());
+                                AuthState.AuthSource source = hasJoinedUrl.isEmpty()
+                                        ? AuthState.AuthSource.MOJANG
+                                        : AuthState.AuthSource.YGGDRASIL;
+                                String displayName = trueuuid$authDisplayName(hasJoinedUrl);
+
+                                TrueuuidRuntime.NAME_REGISTRY.recordSuccess(res.name(), res.uuid(), ip, source, displayName);
+                                TrueuuidRuntime.IP_GRACE.record(res.name(), ip, res.uuid(), source, displayName);
 
                                 GameProfile newProfile = new GameProfile(res.uuid(), res.name());
                                 var propMap = newProfile.getProperties();
@@ -228,6 +263,10 @@ public abstract class ServerLoginMixin {
                                 // the original login tick continue; starting verification a
                                 // second time can inject Forge's login pipeline handlers twice.
                                 this.authenticatedProfile = newProfile;
+                                AuthState.markAuthSuccess(this.connection, res.uuid(), res.name(), source, displayName);
+                                if (TrueuuidConfig.debug()) {
+                                    System.out.println("[TrueUUID] 记录认证成功来源: " + source + ", displayName=" + displayName);
+                                }
                             } catch (Throwable t) {
                                 if (TrueuuidConfig.debug()) {
                                     System.out.println("[TrueUUID] 认证异步处理时发生异常: " + t);
@@ -266,6 +305,9 @@ public abstract class ServerLoginMixin {
                 if (premium != null) {
                     System.out.println("[TrueUUID] 使用近期同 IP 容错按正版 UUID 放行, 玩家: " + name + ", ip: " + ip + ", uuid: " + premium);
                     this.authenticatedProfile = new GameProfile(premium, name);
+                    AuthState.AuthSource cachedSource = d.graceSource != null ? d.graceSource : AuthState.AuthSource.MOJANG;
+                    String cachedName = d.graceDisplayName != null ? d.graceDisplayName : "近期同IP容错";
+                    AuthState.markAuthSuccess(this.connection, premium, name, cachedSource, cachedName);
                 } else {
                     System.out.println("[TrueUUID] 容错未找到正版 UUID，改为离线兜底, 玩家: " + name + ", ip: " + ip);
                     AuthState.markOfflineFallback(this.connection, AuthState.FallbackReason.FAILURE);
@@ -294,6 +336,21 @@ public abstract class ServerLoginMixin {
     private void sendDisconnectWithReason(Component reason) {
         // 登录监听器只能使用 LOGIN 阶段的断开流程，避免混发 PLAY 断开包导致客户端按错误协议解码。
         this.disconnect(reason);
+    }
+
+    @Unique
+    private String trueuuid$authDisplayName(String hasJoinedUrl) {
+        if (hasJoinedUrl == null || hasJoinedUrl.isBlank()) {
+            return "Mojang";
+        }
+        try {
+            URI uri = URI.create(hasJoinedUrl);
+            String host = uri.getHost();
+            if (host != null && !host.isBlank()) {
+                return host;
+            }
+        } catch (Throwable ignored) {}
+        return "Yggdrasil 皮肤站";
     }
 
     @Unique

--- a/src/main/java/cn/alini/trueuuid/net/AuthAnswerPayload.java
+++ b/src/main/java/cn/alini/trueuuid/net/AuthAnswerPayload.java
@@ -3,15 +3,20 @@ package cn.alini.trueuuid.net;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.login.custom.CustomQueryAnswerPayload;
 
-public record AuthAnswerPayload(boolean ok) implements CustomQueryAnswerPayload {
+public record AuthAnswerPayload(boolean ok, String hasJoinedUrl) implements CustomQueryAnswerPayload {
     private static final int CURRENT_VERSION = 1;
+
+    public AuthAnswerPayload(boolean ok) {
+        this(ok, "");
+    }
     
     public AuthAnswerPayload(FriendlyByteBuf buf) {
-        this(buf.readBoolean());
+        this(buf.readBoolean(), buf.isReadable() ? buf.readUtf() : "");
     }
 
     @Override
     public void write(FriendlyByteBuf buf) {
         buf.writeBoolean(ok);
+        buf.writeUtf(hasJoinedUrl != null ? hasJoinedUrl : "");
     }
 }

--- a/src/main/java/cn/alini/trueuuid/server/AuthDecider.java
+++ b/src/main/java/cn/alini/trueuuid/server/AuthDecider.java
@@ -11,6 +11,8 @@ public final class AuthDecider {
         public enum Kind { PREMIUM_GRACE, OFFLINE, DENY }
         public Kind kind;
         public UUID premiumUuid; // PREMIUM_GRACE 时填
+        public AuthState.AuthSource graceSource;
+        public String graceDisplayName;
         public String denyMessage;
     }
 
@@ -27,6 +29,8 @@ public final class AuthDecider {
             if (premiumUuid.isPresent()) {
                 d.kind = Decision.Kind.PREMIUM_GRACE;
                 d.premiumUuid = premiumUuid.get();
+                d.graceSource = AuthState.AuthSource.MOJANG;
+                d.graceDisplayName = "本地代理容错";
                 return d;
             }
         }
@@ -35,18 +39,26 @@ public final class AuthDecider {
         // 必须优先于 knownPremiumDenyOffline，否则“刚刚成功验证过的正版名”在 Mojang 短暂失败时会被直接拒绝，
         // 配置里的 recentIpGrace.enabled/ttlSeconds 就失去意义。
         if (TrueuuidConfig.recentIpGraceEnabled()) {
-            Optional<UUID> p = TrueuuidRuntime.IP_GRACE.tryGrace(name, ip, TrueuuidConfig.recentIpGraceTtlSeconds());
+            Optional<RecentIpGraceCache.GraceResult> p = TrueuuidRuntime.IP_GRACE.tryGraceResult(name, ip, TrueuuidConfig.recentIpGraceTtlSeconds());
             if (p.isPresent()) {
                 d.kind = Decision.Kind.PREMIUM_GRACE;
-                d.premiumUuid = p.get();
+                d.premiumUuid = p.get().premiumUuid();
+                d.graceSource = p.get().source();
+                d.graceDisplayName = p.get().displayName();
                 return d;
             }
         }
 
         // 2) 已验证过正版的名字：禁止离线回落
         if (known && TrueuuidConfig.knownPremiumDenyOffline()) {
+            AuthState.AuthSource source = TrueuuidRuntime.NAME_REGISTRY.getAuthSource(name);
+            String displayName = TrueuuidRuntime.NAME_REGISTRY.getAuthDisplayName(name);
             d.kind = Decision.Kind.DENY;
-            d.denyMessage = "该名称已绑定正版 UUID，鉴权失败时不允许以离线模式进入。请检查网络后重试。";
+            if (source == AuthState.AuthSource.YGGDRASIL) {
+                d.denyMessage = "该名称已绑定皮肤站 UUID（" + displayName + "），鉴权失败时不允许以离线模式进入。请使用对应皮肤站登录后重试。";
+            } else {
+                d.denyMessage = "该名称已绑定正版 UUID，鉴权失败时不允许以离线模式进入。请检查网络后重试。";
+            }
             return d;
         }
 

--- a/src/main/java/cn/alini/trueuuid/server/AuthDecider.java
+++ b/src/main/java/cn/alini/trueuuid/server/AuthDecider.java
@@ -19,6 +19,18 @@ public final class AuthDecider {
 
         boolean known = TrueuuidRuntime.NAME_REGISTRY.isKnownPremiumName(name);
 
+        // Velocity/VC proxy compatibility: if the modded client answered the
+        // trueuuid:auth query but Mojang hasJoined still fails behind a local
+        // proxy, preserve the already-bound premium UUID instead of denying.
+        if (known && isLocalProxyAddress(ip)) {
+            Optional<UUID> premiumUuid = TrueuuidRuntime.NAME_REGISTRY.getPremiumUuid(name);
+            if (premiumUuid.isPresent()) {
+                d.kind = Decision.Kind.PREMIUM_GRACE;
+                d.premiumUuid = premiumUuid.get();
+                return d;
+            }
+        }
+
         // 1) 已验证过正版的名字：禁止离线回落
         if (known && TrueuuidConfig.knownPremiumDenyOffline()) {
             d.kind = Decision.Kind.DENY;
@@ -46,6 +58,16 @@ public final class AuthDecider {
         d.kind = Decision.Kind.DENY;
         d.denyMessage = "鉴权失败，已禁止离线进入以保护你的正版存档。请稍后重试。";
         return d;
+    }
+
+    private static boolean isLocalProxyAddress(String ip) {
+        if (ip == null || ip.isBlank()) {
+            return false;
+        }
+        return "127.0.0.1".equals(ip)
+                || "0:0:0:0:0:0:0:1".equals(ip)
+                || "::1".equals(ip)
+                || "localhost".equalsIgnoreCase(ip);
     }
 
     private AuthDecider() {}

--- a/src/main/java/cn/alini/trueuuid/server/AuthDecider.java
+++ b/src/main/java/cn/alini/trueuuid/server/AuthDecider.java
@@ -31,14 +31,9 @@ public final class AuthDecider {
             }
         }
 
-        // 1) 已验证过正版的名字：禁止离线回落
-        if (known && TrueuuidConfig.knownPremiumDenyOffline()) {
-            d.kind = Decision.Kind.DENY;
-            d.denyMessage = "该名称已绑定正版 UUID，鉴权失败时不允许以离线模式进入。请检查网络后重试。";
-            return d;
-        }
-
-        // 2) 近期同 IP 成功容错：临时按正版处理
+        // 1) 近期同 IP 成功容错：临时按正版处理。
+        // 必须优先于 knownPremiumDenyOffline，否则“刚刚成功验证过的正版名”在 Mojang 短暂失败时会被直接拒绝，
+        // 配置里的 recentIpGrace.enabled/ttlSeconds 就失去意义。
         if (TrueuuidConfig.recentIpGraceEnabled()) {
             Optional<UUID> p = TrueuuidRuntime.IP_GRACE.tryGrace(name, ip, TrueuuidConfig.recentIpGraceTtlSeconds());
             if (p.isPresent()) {
@@ -46,6 +41,13 @@ public final class AuthDecider {
                 d.premiumUuid = p.get();
                 return d;
             }
+        }
+
+        // 2) 已验证过正版的名字：禁止离线回落
+        if (known && TrueuuidConfig.knownPremiumDenyOffline()) {
+            d.kind = Decision.Kind.DENY;
+            d.denyMessage = "该名称已绑定正版 UUID，鉴权失败时不允许以离线模式进入。请检查网络后重试。";
+            return d;
         }
 
         // 3) 未知名字：可允许离线兜底

--- a/src/main/java/cn/alini/trueuuid/server/AuthState.java
+++ b/src/main/java/cn/alini/trueuuid/server/AuthState.java
@@ -2,7 +2,9 @@ package cn.alini.trueuuid.server;
 
 import net.minecraft.network.Connection;
 
+import java.util.Locale;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -11,11 +13,39 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class AuthState {
     public enum FallbackReason { TIMEOUT, FAILURE }
 
+    public enum AuthSource { MOJANG, YGGDRASIL }
+
+    public record AuthSuccess(AuthSource source, String displayName) {}
+
     private static final ConcurrentHashMap<Connection, FallbackReason> OFFLINE_FALLBACK = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<Connection, AuthSuccess> AUTH_SUCCESS = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, AuthSuccess> AUTH_SUCCESS_BY_PROFILE = new ConcurrentHashMap<>();
 
     public static void markOfflineFallback(Connection conn, FallbackReason reason) {
         if (conn != null && reason != null) {
             OFFLINE_FALLBACK.put(conn, reason);
+            AUTH_SUCCESS.remove(conn);
+        }
+    }
+
+    public static void markAuthSuccess(Connection conn, AuthSource source, String displayName) {
+        if (conn != null && source != null) {
+            String normalizedName = displayName == null || displayName.isBlank() ? source.name() : displayName;
+            AUTH_SUCCESS.put(conn, new AuthSuccess(source, normalizedName));
+            OFFLINE_FALLBACK.remove(conn);
+        }
+    }
+
+    public static void markAuthSuccess(Connection conn, UUID uuid, String name, AuthSource source, String displayName) {
+        markAuthSuccess(conn, source, displayName);
+        if (source == null) return;
+        String normalizedName = displayName == null || displayName.isBlank() ? source.name() : displayName;
+        AuthSuccess success = new AuthSuccess(source, normalizedName);
+        if (uuid != null) {
+            AUTH_SUCCESS_BY_PROFILE.put("uuid:" + uuid, success);
+        }
+        if (name != null && !name.isBlank()) {
+            AUTH_SUCCESS_BY_PROFILE.put("name:" + name.toLowerCase(Locale.ROOT), success);
         }
     }
 
@@ -23,6 +53,26 @@ public final class AuthState {
         if (conn == null) return Optional.empty();
         FallbackReason r = OFFLINE_FALLBACK.remove(conn);
         return Optional.ofNullable(r);
+    }
+
+    public static Optional<AuthSuccess> consumeAuthSuccess(Connection conn) {
+        if (conn == null) return Optional.empty();
+        AuthSuccess success = AUTH_SUCCESS.remove(conn);
+        return Optional.ofNullable(success);
+    }
+
+    public static Optional<AuthSuccess> consumeAuthSuccess(Connection conn, UUID uuid, String name) {
+        Optional<AuthSuccess> byConnection = consumeAuthSuccess(conn);
+        if (byConnection.isPresent()) return byConnection;
+        if (uuid != null) {
+            AuthSuccess success = AUTH_SUCCESS_BY_PROFILE.remove("uuid:" + uuid);
+            if (success != null) return Optional.of(success);
+        }
+        if (name != null && !name.isBlank()) {
+            AuthSuccess success = AUTH_SUCCESS_BY_PROFILE.remove("name:" + name.toLowerCase(Locale.ROOT));
+            if (success != null) return Optional.of(success);
+        }
+        return Optional.empty();
     }
 
     private AuthState() {}

--- a/src/main/java/cn/alini/trueuuid/server/NameRegistry.java
+++ b/src/main/java/cn/alini/trueuuid/server/NameRegistry.java
@@ -16,6 +16,8 @@ public class NameRegistry {
         public long firstVerifiedAt;
         public long lastVerifiedAt;
         public String lastSuccessIp;
+        public AuthState.AuthSource authSource;
+        public String authDisplayName;
     }
 
     private final Path file;
@@ -36,10 +38,29 @@ public class NameRegistry {
         return map.containsKey(name.toLowerCase(Locale.ROOT));
     }
 
+    public synchronized AuthState.AuthSource getAuthSource(String name) {
+        Entry e = map.get(name.toLowerCase(Locale.ROOT));
+        return e == null || e.authSource == null ? AuthState.AuthSource.MOJANG : e.authSource;
+    }
+
+    public synchronized String getAuthDisplayName(String name) {
+        Entry e = map.get(name.toLowerCase(Locale.ROOT));
+        if (e == null || e.authDisplayName == null || e.authDisplayName.isBlank()) {
+            return getAuthSource(name) == AuthState.AuthSource.YGGDRASIL ? "Yggdrasil 皮肤站" : "Mojang";
+        }
+        return e.authDisplayName;
+    }
+
     public synchronized void recordSuccess(String name, UUID premiumUuid, String ip) {
+        recordSuccess(name, premiumUuid, ip, AuthState.AuthSource.MOJANG, "Mojang");
+    }
+
+    public synchronized void recordSuccess(String name, UUID premiumUuid, String ip, AuthState.AuthSource source, String displayName) {
         String k = name.toLowerCase(Locale.ROOT);
         Entry e = map.getOrDefault(k, new Entry());
         e.premiumUuid = premiumUuid;
+        e.authSource = source != null ? source : AuthState.AuthSource.MOJANG;
+        e.authDisplayName = displayName == null || displayName.isBlank() ? e.authSource.name() : displayName;
         long now = Instant.now().toEpochMilli();
         if (e.firstVerifiedAt == 0) e.firstVerifiedAt = now;
         e.lastVerifiedAt = now;
@@ -60,6 +81,14 @@ public class NameRegistry {
                         en.firstVerifiedAt = e.get("firstVerifiedAt").getAsLong();
                         en.lastVerifiedAt = e.get("lastVerifiedAt").getAsLong();
                         if (e.has("lastSuccessIp")) en.lastSuccessIp = e.get("lastSuccessIp").getAsString();
+                        if (e.has("authSource")) {
+                            try {
+                                en.authSource = AuthState.AuthSource.valueOf(e.get("authSource").getAsString());
+                            } catch (IllegalArgumentException ignored) {
+                                en.authSource = AuthState.AuthSource.MOJANG;
+                            }
+                        }
+                        if (e.has("authDisplayName")) en.authDisplayName = e.get("authDisplayName").getAsString();
                         map.put(k, en);
                     }
                 }
@@ -84,6 +113,10 @@ public class NameRegistry {
                 e.addProperty("lastVerifiedAt", me.getValue().lastVerifiedAt);
                 if (me.getValue().lastSuccessIp != null)
                     e.addProperty("lastSuccessIp", me.getValue().lastSuccessIp);
+                if (me.getValue().authSource != null)
+                    e.addProperty("authSource", me.getValue().authSource.name());
+                if (me.getValue().authDisplayName != null)
+                    e.addProperty("authDisplayName", me.getValue().authDisplayName);
                 o.add(me.getKey(), e);
             }
             try (Writer w = Files.newBufferedWriter(file, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {

--- a/src/main/java/cn/alini/trueuuid/server/RecentIpGraceCache.java
+++ b/src/main/java/cn/alini/trueuuid/server/RecentIpGraceCache.java
@@ -4,9 +4,13 @@ import java.time.Instant;
 import java.util.*;
 
 public class RecentIpGraceCache {
+    public record GraceResult(UUID premiumUuid, AuthState.AuthSource source, String displayName) {}
+
     private static class Rec {
         UUID premiumUuid;
-        long lastSuccessAt;
+        AuthState.AuthSource source;
+        String displayName;
+        long graceStartedAt;
     }
 
     private final Map<String, Rec> map = new HashMap<>();
@@ -16,27 +20,61 @@ public class RecentIpGraceCache {
     }
 
     public synchronized void record(String name, String ip, UUID premiumUuid) {
+        record(name, ip, premiumUuid, AuthState.AuthSource.MOJANG, "Mojang");
+    }
+
+    public synchronized void record(String name, String ip, UUID premiumUuid, AuthState.AuthSource source, String displayName) {
         if (ip == null || ip.isEmpty()) return;
         Rec r = new Rec();
         r.premiumUuid = premiumUuid;
-        r.lastSuccessAt = Instant.now().toEpochMilli();
+        r.source = source != null ? source : AuthState.AuthSource.MOJANG;
+        r.displayName = displayName == null || displayName.isBlank() ? r.source.name() : displayName;
+        r.graceStartedAt = 0L;
         map.put(key(name, ip), r);
+    }
+
+    public synchronized void activateAfterLogout(String name, String ip) {
+        if (ip == null || ip.isEmpty()) return;
+        Rec r = map.get(key(name, ip));
+        if (r != null) {
+            r.graceStartedAt = Instant.now().toEpochMilli();
+        }
     }
 
     public synchronized Optional<UUID> tryGrace(String name, String ip, int ttlSeconds) {
         if (ip == null || ip.isEmpty()) return Optional.empty();
         Rec r = map.get(key(name, ip));
         if (r == null) return Optional.empty();
+        if (r.graceStartedAt <= 0L) return Optional.empty();
         long now = Instant.now().toEpochMilli();
-        if (now - r.lastSuccessAt <= ttlSeconds * 1000L) {
-            return Optional.of(r.premiumUuid);
+        if (now - r.graceStartedAt <= ttlSeconds * 1000L) {
+            UUID premiumUuid = r.premiumUuid;
+            map.remove(key(name, ip));
+            return Optional.of(premiumUuid);
         }
+        map.remove(key(name, ip));
+        return Optional.empty();
+    }
+
+    public synchronized Optional<GraceResult> tryGraceResult(String name, String ip, int ttlSeconds) {
+        if (ip == null || ip.isEmpty()) return Optional.empty();
+        Rec r = map.get(key(name, ip));
+        if (r == null) return Optional.empty();
+        if (r.graceStartedAt <= 0L) return Optional.empty();
+        long now = Instant.now().toEpochMilli();
+        if (now - r.graceStartedAt <= ttlSeconds * 1000L) {
+            AuthState.AuthSource source = r.source != null ? r.source : AuthState.AuthSource.MOJANG;
+            String displayName = r.displayName == null || r.displayName.isBlank() ? source.name() : r.displayName;
+            map.remove(key(name, ip));
+            return Optional.of(new GraceResult(r.premiumUuid, source, displayName));
+        }
+        map.remove(key(name, ip));
         return Optional.empty();
     }
 
     public synchronized void cleanup(int ttlSeconds) {
         long now = Instant.now().toEpochMilli();
-        map.entrySet().removeIf(e -> now - e.getValue().lastSuccessAt > ttlSeconds * 1000L);
+        map.entrySet().removeIf(e -> e.getValue().graceStartedAt > 0L && now - e.getValue().graceStartedAt > ttlSeconds * 1000L);
     }
 
 }

--- a/src/main/java/cn/alini/trueuuid/server/SessionCheck.java
+++ b/src/main/java/cn/alini/trueuuid/server/SessionCheck.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 public final class SessionCheck {
     private static final HttpClient HTTP = HttpClient.newHttpClient();
     private static final Gson GSON = new Gson();
+    private static final String MOJANG_HAS_JOINED = "https://sessionserver.mojang.com/session/minecraft/hasJoined";
 
     public record Property(String name, String value, String signature) {}
 
@@ -43,12 +44,19 @@ public final class SessionCheck {
      * 异步版本：不阻塞调用线程，返回 CompletableFuture\<Optional\<HasJoinedResult\>\>
      */
     public static CompletableFuture<Optional<HasJoinedResult>> hasJoinedAsync(String username, String serverId, String ip) {
-        String url = TrueuuidConfig.COMMON.mojangReverseProxy.get()+"/session/minecraft/hasJoined"
+        return hasJoinedAsync(username, serverId, ip, "");
+    }
+
+    public static CompletableFuture<Optional<HasJoinedResult>> hasJoinedAsync(String username, String serverId, String ip, String hasJoinedBaseUrl) {
+        String baseUrl = hasJoinedBaseUrl == null || hasJoinedBaseUrl.isBlank()
+                ? trueuuid$mojangHasJoinedUrl()
+                : hasJoinedBaseUrl.trim();
+        String url = baseUrl
                 + "?username=" + URLEncoder.encode(username, StandardCharsets.UTF_8)
                 + "&serverId=" + URLEncoder.encode(serverId, StandardCharsets.UTF_8);
 
         if (cn.alini.trueuuid.config.TrueuuidConfig.debug()) {
-            System.out.println("[TrueUUID][DEBUG] 请求 Mojang 校验接口: " + url);
+            System.out.println("[TrueUUID][DEBUG] 请求会话校验接口: " + url + (hasJoinedBaseUrl == null || hasJoinedBaseUrl.isBlank() ? " (Mojang)" : " (自定义)"));
         }
 
         HttpRequest req = HttpRequest.newBuilder(URI.create(url)).GET().build();
@@ -56,8 +64,8 @@ public final class SessionCheck {
         return HTTP.sendAsync(req, HttpResponse.BodyHandlers.ofString())
                 .thenApply(resp -> {
                     if (cn.alini.trueuuid.config.TrueuuidConfig.debug()) {
-                        System.out.println("[TrueUUID][DEBUG] Mojang 响应状态码: " + resp.statusCode());
-                        System.out.println("[TrueUUID][DEBUG] Mojang 响应内容: " + resp.body());
+                        System.out.println("[TrueUUID][DEBUG] 响应状态码: " + resp.statusCode());
+                        System.out.println("[TrueUUID][DEBUG] 响应内容: " + resp.body());
                     }
 
                     if (resp.statusCode() != 200) {
@@ -92,10 +100,19 @@ public final class SessionCheck {
                 })
                 .exceptionally(ex -> {
                     if (cn.alini.trueuuid.config.TrueuuidConfig.debug()) {
-                        System.out.println("[TrueUUID][DEBUG] 与 Mojang 通信或解析时发生异常: " + ex);
+                        System.out.println("[TrueUUID][DEBUG] 与会话服务通信或解析时发生异常: " + ex);
                     }
                     return Optional.empty();
                 });
+    }
+
+    private static String trueuuid$mojangHasJoinedUrl() {
+        String reverseProxy = TrueuuidConfig.mojangReverseProxy();
+        if (reverseProxy == null || reverseProxy.isBlank() || "https://sessionserver.mojang.com".equals(reverseProxy)) {
+            return MOJANG_HAS_JOINED;
+        }
+        String root = reverseProxy.endsWith("/") ? reverseProxy.substring(0, reverseProxy.length() - 1) : reverseProxy;
+        return root + "/session/minecraft/hasJoined";
     }
 
     // 保留同步方法（若需要）或移除

--- a/src/main/java/cn/alini/trueuuid/server/SkinRefreshHandler.java
+++ b/src/main/java/cn/alini/trueuuid/server/SkinRefreshHandler.java
@@ -15,6 +15,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 
+import java.net.InetSocketAddress;
 import java.util.List;
 
 /**
@@ -45,6 +46,7 @@ public class SkinRefreshHandler {
         // 2) 判断是否离线放行，并发送聊天提示 + 屏幕标题（副标题使用短文案）
         var netConn = sp.connection.getConnection(); // ServerGamePacketListenerImpl.connection
         var fallbackOpt = AuthState.consume(netConn);
+        var successOpt = AuthState.consumeAuthSuccess(netConn, sp.getUUID(), sp.getGameProfile().getName());
 
         if (fallbackOpt.isPresent()) {
             // 聊天提示：长文案
@@ -59,19 +61,62 @@ public class SkinRefreshHandler {
             String shortSubtitle = TrueuuidConfig.offlineShortSubtitle();
             var subtitle = Component.literal(clamp(shortSubtitle, SUBTITLE_MAX_CHARS)).withStyle(ChatFormatting.YELLOW);
 
-            sp.connection.send(new ClientboundSetTitlesAnimationPacket(10, 60, 10));
-            sp.connection.send(new ClientboundSetTitleTextPacket(title));
-            sp.connection.send(new ClientboundSetSubtitleTextPacket(subtitle));
-        } else {
+            sendTitleNextTick(server, sp, title, subtitle, "OFFLINE");
+        } else if (successOpt.isPresent() && successOpt.get().source() == AuthState.AuthSource.YGGDRASIL) {
+            AuthState.AuthSuccess success = successOpt.get();
+            var title = Component.literal("皮肤站登录").withStyle(ChatFormatting.AQUA);
+            String sourceName = success.displayName();
+            var subtitle = Component.literal(clamp("已通过 " + sourceName + " 校验", SUBTITLE_MAX_CHARS)).withStyle(ChatFormatting.GREEN);
+
+            sendTitleNextTick(server, sp, title, subtitle, "YGGDRASIL:" + sourceName);
+        } else if (successOpt.isPresent()) {
             // 正版模式：绿色标题，副标题短文案（灰色）
             var title = Component.literal("正版模式").withStyle(ChatFormatting.GREEN);
             String shortSubtitle = TrueuuidConfig.onlineShortSubtitle();
             var subtitle = Component.literal(clamp(shortSubtitle, SUBTITLE_MAX_CHARS)).withStyle(ChatFormatting.GRAY);
 
+            String mode = "MOJANG:" + successOpt.get().displayName();
+            sendTitleNextTick(server, sp, title, subtitle, mode);
+        } else if (!server.isDedicatedServer()) {
+            var title = Component.literal("单人模式").withStyle(ChatFormatting.GOLD);
+            var subtitle = Component.literal("未进行服务器鉴权").withStyle(ChatFormatting.GRAY);
+
+            sendTitleNextTick(server, sp, title, subtitle, "SINGLEPLAYER");
+        } else if (TrueuuidConfig.debug()) {
+            System.out.println("[TrueUUID] 跳过登录标题: 玩家=" + sp.getGameProfile().getName() + ", 原因=未经过 TrueUUID 登录认证状态");
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public static void onLogout(PlayerEvent.PlayerLoggedOutEvent event) {
+        if (!(event.getEntity() instanceof ServerPlayer sp)) return;
+        String ip = trueuuid$ipOf(sp);
+        if (ip == null || ip.isBlank()) return;
+        TrueuuidRuntime.IP_GRACE.activateAfterLogout(sp.getGameProfile().getName(), ip);
+        if (TrueuuidConfig.debug()) {
+            System.out.println("[TrueUUID] 玩家退出，开启近期同 IP 容错窗口: 玩家=" + sp.getGameProfile().getName() + ", ip=" + ip + ", ttl=" + TrueuuidConfig.recentIpGraceTtlSeconds() + "s");
+        }
+    }
+
+    private static String trueuuid$ipOf(ServerPlayer sp) {
+        if (sp.connection.getConnection().getRemoteAddress() instanceof InetSocketAddress isa) {
+            return isa.getAddress().getHostAddress();
+        }
+        return null;
+    }
+
+    private static void sendTitleNextTick(net.minecraft.server.MinecraftServer server, ServerPlayer sp, Component title, Component subtitle, String mode) {
+        server.execute(() -> {
+            if (sp.hasDisconnected()) {
+                return;
+            }
+            if (TrueuuidConfig.debug()) {
+                System.out.println("[TrueUUID] 发送登录标题: 玩家=" + sp.getGameProfile().getName() + ", mode=" + mode);
+            }
             sp.connection.send(new ClientboundSetTitlesAnimationPacket(10, 60, 10));
             sp.connection.send(new ClientboundSetTitleTextPacket(title));
             sp.connection.send(new ClientboundSetSubtitleTextPacket(subtitle));
-        }
+        });
     }
 
     private static String clamp(String s, int max) {

--- a/src/main/java/cn/alini/trueuuid/server/SkinRefreshHandler.java
+++ b/src/main/java/cn/alini/trueuuid/server/SkinRefreshHandler.java
@@ -33,8 +33,13 @@ public class SkinRefreshHandler {
         // 1) 登录后一帧刷新外观（强制客户端重拉皮肤）
         server.execute(() -> {
             var list = server.getPlayerList();
-            list.broadcastAll(new ClientboundPlayerInfoRemovePacket(List.of(sp.getUUID())));
-            list.broadcastAll(ClientboundPlayerInfoUpdatePacket.createPlayerInitializing(List.of(sp)));
+            var removePacket = new ClientboundPlayerInfoRemovePacket(List.of(sp.getUUID()));
+            var updatePacket = ClientboundPlayerInfoUpdatePacket.createPlayerInitializing(List.of(sp));
+            for (ServerPlayer player : list.getPlayers()) {
+                if (player.getUUID().equals(sp.getUUID())) continue;
+                player.connection.send(removePacket);
+                player.connection.send(updatePacket);
+            }
         });
 
         // 2) 判断是否离线放行，并发送聊天提示 + 屏幕标题（副标题使用短文案）


### PR DESCRIPTION
## Summary
- 同步 1.21 NeoForge 登录流水线修复，避免 TrueUUID 自定义鉴权与 NeoForge 登录流程时序冲突。
- 将鉴权等待默认超时调整为 30 秒，并在等待 Mojang 验证时显示原版“正在登录中...”提示。
- 优化正版玩家近期同 IP 容错、登录断开处理和鉴权失败日志，减少网络波动导致的误踢。

## Verification
- 已在本地执行 NeoForge 1.21.1 `clean build` 成功。
- 已在测试客户端和测试服务端部署验证 TrueUUID 1.0.7 加载与进服流程。