### PR TITLE
发布 TrueUUID 1.0.9（Forge 1.20.1）

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,154 +2,216 @@
 
 English | [简体中文](README_zh-CN.md)
 
-A Forge 1.20.x mod that securely verifies premium accounts on an offline-mode server during the login phase, without sending the player's access token to the server.
+TrueUUID is a login-phase authentication mod for offline-mode Minecraft servers.
 
-TrueUUID lets an offline-mode server:
-- Ask the client to perform Mojang "joinServer" locally.
-- Verify with Mojang Session Server from the server using a nonce.
-- If verification passes: replace the player's UUID with the official premium UUID, fix username casing, and inject skin properties.
-- If verification fails or times out: configurable behavior (kick on timeout by default; controlled fallbacks for failures).
-- Inform the player on join with a Title whether they are in "Online/Premium Mode" or "Offline Mode" and send an explanatory chat message for offline fallback.
+It lets an offline-mode server verify premium Mojang accounts, and supported Yggdrasil/authlib-injector skin-site accounts, without ever receiving the player's access token.
 
-Note: Client and server must both install this mod. The server must run in offline mode.
+Both the client and the server must install this mod. The server must run with:
 
-## Highlights
+```properties
+online-mode=false
+```
 
-- Privacy-preserving: the player's access token never leaves the client. The client calls `joinServer(profile, token, nonce)` locally.
-- Better identity integrity: even in offline mode, verified players keep their official UUID and skins.
-- Clear UX: Title messages for premium vs offline mode, plus a chat hint when falling back to offline.
-- Data safety policies to prevent data split between online/offline UUIDs.
+## Features
 
-## New features and policies
+- Privacy-preserving authentication: the player's access token is only used locally on the client.
+- Premium/Yggdrasil UUID support on offline-mode servers.
+- Correct username casing after successful verification.
+- Signed skin texture injection during login.
+- Player info refresh after joining, helping skins update correctly.
+- Clear join feedback for premium, skin-site, and offline fallback states.
+- Offline-to-verified player data migration with confirmation and backups.
+- Protection against known verified players rejoining with the same name in offline mode.
 
-- Name Registry: Persistently records names that have successfully verified as premium (name -> premium UUID).
-- Policy: knownPremiumDenyOffline
-    - Once a name has verified as premium, future auth failures will deny offline fallback for that name (to prevent data divergence).
-- Policy: allowOfflineForUnknownOnly
-    - Only allow offline fallback for names that have never verified as premium.
-- Recent IP Grace (optional)
-    - After a player has already verified successfully and then disconnects, the same name and IP may reuse that verified UUID only within a short logout window (default: 10 seconds) if the next verification fails. This is intended for immediate reconnects only and is consumed after one use.
-- Admin command: /trueuuid link <name>
-    - Migrate/merge an offline UUID’s data to the premium UUID. Supports dry-run and backups.
-- Reliable disconnect reason on 1.20.x Forge
-    - During login, the server now explicitly sends the login/game disconnect packet so the client shows the detailed reason, not just “Disconnected”.
+## Why
 
-## How it works
+Offline-mode servers normally cannot trust player UUIDs. TrueUUID improves identity integrity while keeping the server in offline mode.
 
-1. Server is in offline mode. During login (HELLO), the server sends a custom login query with a nonce (transactionId + identifier `trueuuid:auth` + data).
-2. The modded client intercepts this query, reads the nonce, and locally calls `MinecraftSessionService.joinServer(profile, token, nonce)` (token never sent to the server).
-3. The client replies with a boolean ack (no sensitive data).
-4. The server calls Mojang Session Server `/hasJoined?username={name}&serverId={nonce}[&ip={ip}]`.
-5. If success:
-    - Replace the pending login `GameProfile` with premium UUID and the name returned from Mojang (ensuring correct casing).
-    - Inject skin properties (textures) with signature into the `GameProfile` property map.
-    - After join, force-refresh player info so skins update.
-    - Show a green Title “Premium Mode” with a short subtitle (configurable).
-6. If failure:
-    - By default:
-        - Timeout: kick with configurable message.
-        - Failure: behavior governed by policies below (see Configuration). Offline fallback shows a red Title “Offline Mode” with a short subtitle and chat explanation.
+Verified players can keep their official Mojang or Yggdrasil UUID and skin data, while the server never sees their access token.
+
+This is useful for modpacks, LAN-style servers, private offline-mode communities, and servers that want better identity consistency without enabling Mojang online-mode directly.
+
+## How It Works
+
+1. The server runs in offline mode.
+2. During login, the server sends a custom login query with a nonce.
+3. The modded client receives the query and locally calls `joinServer` with the player's profile, token, and nonce. The token never leaves the client.
+4. The client replies with the authentication result and the selected authentication source.
+5. The server verifies the nonce through Mojang Session Server or a supported Yggdrasil `hasJoined` endpoint.
+6. If verification succeeds:
+   - The pending login profile is replaced with the verified UUID.
+   - Username casing is corrected.
+   - Signed skin texture properties are injected.
+   - The authentication source is recorded.
+   - Player info is refreshed after joining.
+7. If verification fails or times out:
+   - Behavior is controlled by the config.
+   - Known verified names can be prevented from falling back to offline mode.
+   - Unknown names may still be allowed to use offline fallback if configured.
+
+## Offline Data Migration
+
+TrueUUID 1.0.9 adds a safer migration flow for players who used to play offline and later switch to a premium or skin-site account with the same name.
+
+When a verified login detects matching offline UUID data, the player will see a confirmation screen. Migration only happens after confirmation.
+
+Before migration, TrueUUID backs up both the old offline data and any existing target verified UUID data.
+
+Supported migration targets include:
+
+- Vanilla `playerdata`
+- Vanilla `playerdata_old`
+- Advancements
+- Stats
+- Cosmetic Armor `.cosarmor` data
+- Open Parties and Claims
+- FTB Chunks
+- FTB Essentials
+- FTB Teams
+- FTB Quests
+- FTB Ranks
+- CustomNPCs playerdata
 
 ## Requirements
 
-- Minecraft: 1.20.x
-- Forge: 47.x (e.g., 47.4.0+)
+Forge build:
+
+- Minecraft: 1.20.1
+- Forge: 47.x
 - Java: 17
-- Client and server must both install this mod.
-- Server property: `online-mode=false`
+
+NeoForge build:
+
+- Minecraft: 1.21.1
+- NeoForge: 21.1.x
+- Java: 21
+
+Client and server must both install TrueUUID.
+
+## Installation
+
+Server:
+
+1. Set `online-mode=false` in `server.properties`.
+2. Place the matching TrueUUID jar in the server's `mods` folder.
+
+Client:
+
+1. Place the matching TrueUUID jar in the client's `mods` folder.
+
+If the client does not have this mod installed, the server will not receive the expected login query response. Depending on configuration, the player may be kicked or allowed to fall back to offline mode.
 
 ## Configuration
 
-Generated at first run:
-- `config/trueuuid-common.toml`
+After the first run, the config file is generated at:
 
-Keys and defaults:
+```text
+config/trueuuid-common.toml
+```
 
-- auth.timeoutMs = 10000
-    - Login-phase wait time (ms) for the client's reply.
-- auth.allowOfflineOnTimeout = false
-    - false: kick on timeout (default)
-    - true: allow offline fallback if timeout occurs
-- auth.allowOfflineOnFailure = true
-    - Legacy broad fallback switch; fine-grained new policies below take precedence in most flows.
-- auth.timeoutKickMessage = "登录超时，未完成账号校验"
-    - Kick reason shown on timeout.
-- auth.offlineFallbackMessage = "注意：你当前以离线模式进入服务器；如果你是正版账号，可能是网络原因导致无法成功鉴权，请重新登陆重试。继续游玩，若后续鉴权成功可能会丢失玩家数据。"
-    - Chat message shown to the player if they were allowed in via offline fallback.
-- auth.offlineShortSubtitle = "鉴权失败：离线模式"
-    - Short subtitle for Title when in offline mode.
-- auth.onlineShortSubtitle = "已通过正版校验"
-    - Short subtitle for Title when in premium mode.
-- auth.knownPremiumDenyOffline = true
-    - If a name has ever verified as premium, deny offline fallback on later failures (prevents data splitting).
-- auth.allowOfflineForUnknownOnly = true
-    - Only names that have never verified as premium may fall back to offline.
-- auth.recentIpGrace.enabled = true
-    - Enable same-IP short reconnect grace after a verified player disconnects.
-- auth.recentIpGrace.ttlSeconds = 10
-    - Seconds after logout during which the same name and IP may reuse the last verified UUID. Valid range: 1–60. The grace entry is consumed after one use.
-- auth.yggdrasil.apiRootWhitelist = []
-    - Optional authlib-injector/Yggdrasil skin-site URL whitelist. Empty means trust the client-reported skin-site `hasJoined` endpoint. Add entries such as `["littleskin.cn"]` to only accept matching endpoints.
+Important options:
 
-Notes:
-- Recent IP Grace is a usability feature, not strong security. Keep the logout window short and avoid enabling it on shared networks if you have strict identity requirements.
-- The legacy `allowOfflineOnFailure` is still respected, but the new policies are recommended.
+```toml
+auth.timeoutMs = 30000
+```
 
-## Commands
+Login-phase wait time in milliseconds.
 
-- /trueuuid link <name>
-    - Migrate data from the offline UUID (derived from name) to the premium UUID recorded in the registry.
-    - Subcommands (examples):
-        - /trueuuid link dryrun <name>  — show planned moves/merges, no writes.
-        - /trueuuid link run <name>     — perform migration (backs up by default in the example implementation).
-    - Behavior:
-        - If premium data files do not exist, offline files are moved to premium.
-        - If both exist, premium wins by default; merging of inventories/ender/stats can be implemented as needed (placeholders provided).
+```toml
+auth.allowOfflineOnTimeout = false
+```
 
-Affected files (per UUID):
-- world/playerdata/<uuid>.dat
-- world/advancements/<uuid>.json
-- world/stats/<uuid>.json
+`false`: kick on timeout.
 
-Backups:
-- Stored under world/backups/trueuuid/<timestamp>/<name>/
+`true`: allow offline fallback on timeout.
 
-## Troubleshooting
+```toml
+auth.allowOfflineOnFailure = true
+```
 
-- Client shows “Disconnected” without the custom reason:
-    - On Forge 47.4.x, login/config stages can race. The server side now explicitly sends both login and game disconnect packets before closing to ensure the client UI displays the reason. If you still see plain “Disconnected”, test with a clean client (no UI/GUI overhaul mods).
+`true`: allow offline fallback for normal verification failures.
 
-- Skins not updating immediately:
-    - The server broadcasts a PlayerInfo refresh on join. If a client-side mod overrides skin handling, ensure it does not block vanilla updates.
+`false`: disconnect on verification failure.
 
-## Compatibility and notes
+```toml
+auth.knownPremiumDenyOffline = true
+```
 
-- Proxies (Bungee/Velocity): The server optionally includes the client IP in the Mojang `/hasJoined` call when available. If behind a proxy that hides the real IP, verification still works (the IP parameter is optional).
-- Data integrity: With the new policies, once a name is proven premium, offline fallback is denied to prevent “dual identity” and data split.
-- If the client is unmodded: it will not respond to the custom login query. Depending on config/policies, the server may kick or fall back to offline only for unknown names.
+If a name has already been verified as premium or Yggdrasil, deny later offline fallback for that name.
+
+```toml
+auth.allowOfflineForUnknownOnly = true
+```
+
+Only allow offline fallback for names that have never been verified before.
+
+```toml
+auth.recentIpGrace.enabled = true
+auth.recentIpGrace.ttlSeconds = 10
+```
+
+Allows a short same-IP reconnect grace period after a verified player disconnects. This grace is not used when the client explicitly rejects authentication or logs in as offline.
+
+```toml
+auth.nomojang.enabled = false
+```
+
+Disables Mojang session verification when enabled. This is usually not recommended.
+
+```toml
+auth.yggdrasil.apiRootWhitelist = []
+```
+
+Whitelist for Yggdrasil/authlib-injector `hasJoined` URLs. An empty list trusts the endpoint reported by the client. Add entries such as `"littleskin.cn"` to restrict accepted skin-site sources.
+
+NeoForge 1.21.1 also provides:
+
+```toml
+auth.mojangReverseProxy = "https://sessionserver.mojang.com"
+```
+
+Mojang Session Server endpoint. This can be changed to a reverse proxy if needed.
+
+## Compatibility Notes
+
+- Proxies: Mojang's `hasJoined` IP parameter is optional. Verification can still work when the real client IP is hidden by a proxy.
+- Skins: TrueUUID injects signed skin properties during login and refreshes player info after joining. If a client still shows stale skins, rejoining or clearing the skin cache may help.
+- Offline fallback: Offline fallback is configurable. In the recommended setup, previously verified names cannot be reused by offline clients.
+- Registry: TrueUUID stores known verified names in `trueuuid-registry.json`. If this file is cleared, the server forgets previous premium/Yggdrasil bindings.
 
 ## Building
 
-- Clone the repo.
-- Run:
-    - Windows: `gradlew.bat build`
-    - macOS/Linux: `./gradlew build`
-- The built mod is at: `build/libs/trueuuid-<version>.jar`
+Windows:
+
+```powershell
+.\gradlew.bat build
+```
+
+macOS/Linux:
+
+```bash
+./gradlew build
+```
+
+The built mod is written to `build/libs/`.
 
 ## Privacy
 
-- The player's access token is never sent to your server. The token is used locally on the client to call `joinServer`.
-- The server only receives a boolean ack and then itself contacts Mojang's session server to verify the nonce.
+The player's access token is never sent to the server.
+
+The client uses the token locally for `joinServer`. The server only receives the authentication result and verifies the nonce through Mojang Session Server or a supported Yggdrasil endpoint.
 
 ## License
 
-- GNU LGPL 3.0 (see `gradle.properties` / project license)
+GNU LGPL 3.0
 
 ## Credits
 
-- Mojang authlib and session API.
-- Sponge Mixin.
-- ForgeGradle.
+- Mojang authlib and session API
+- Sponge Mixin
+- ForgeGradle
+- NeoForge / ModDevGradle
 
 ---
-Maintained by: [@YuWan-030](https://github.com/YuWan-030)
+
+Maintained by [@YuWan-030](https://github.com/YuWan-030).

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -2,154 +2,216 @@
 
 [English](README.md) | 简体中文
 
-这是一个适用于 Forge 1.20.x 的服务端/客户端同装模组。在离线模式服务器的“登录阶段”安全校验玩家是否为正版账号，且不会把玩家的访问令牌发送到服务器。
+TrueUUID 是一个用于离线模式 Minecraft 服务器的登录阶段账号校验 Mod。
 
-TrueUUID 让离线服也能：
-- 让客户端本地执行 Mojang 的 “joinServer”。
-- 服务器用一次性 nonce 调用 Mojang Session Server 验证。
-- 验证成功：将玩家的 UUID 替换为正版 UUID，修正名字大小写，注入皮肤属性。
-- 验证失败或超时：可配置策略（默认超时踢出；失败按策略决定兜底）。
-- 玩家进服时通过标题提示“正版模式/离线模式”，离线兜底时发送聊天说明。
+它可以让离线模式服务器验证 Mojang 正版账号，以及受支持的 Yggdrasil/authlib-injector 皮肤站账号，同时不会把玩家的 access token 发送给服务器。
 
-注意：客户端与服务端都必须安装本模组；服务器需设置为离线模式（online-mode=false）。
+客户端和服务端都必须安装本 Mod。服务端必须设置：
 
-## 特性亮点
+```properties
+online-mode=false
+```
 
-- 隐私友好：访问令牌只在客户端本地使用，不发送给服务器。
-- 身份一致性：即使在离线服，验证成功的玩家也使用正版 UUID 与皮肤。
-- 体验清晰：标题提示模式，离线兜底时额外聊天说明。
-- 数据安全策略：减少/避免“正版与离线两套 UUID 存档”的分叉风险。
+## 功能
 
-## 新增能力与策略
+- 隐私安全的账号校验：玩家 access token 只在客户端本地使用。
+- 在离线模式服务器上支持正版/Yggdrasil UUID。
+- 验证成功后修正玩家名大小写。
+- 登录阶段注入带签名的皮肤 textures 属性。
+- 玩家进服后刷新玩家信息，帮助皮肤正确更新。
+- 清晰提示玩家当前是正版、皮肤站还是离线兜底状态。
+- 支持离线玩家数据迁移到正版/皮肤站 UUID，迁移前需要确认并自动备份。
+- 防止已验证过的玩家名再次被同名离线账号冒用。
 
-- 名字注册表：持久记录“已成功通过正版校验”的名字及其正版 UUID。
-- 策略：knownPremiumDenyOffline
-    - 一旦某名字被验证为正版，之后该名字鉴权失败时不再允许离线兜底（从源头杜绝数据分叉）。
-- 策略：allowOfflineForUnknownOnly
-    - 仅允许“从未验证为正版”的新名字走离线兜底。
-- 近期同 IP 容错（可选）
-    - 玩家已经成功完成正版/皮肤站校验并退出后，仅在同名同 IP 的短时间重连窗口内（默认 10 秒）允许复用上次验证 UUID；命中一次后即消费。用于处理刚掉线立刻重连，不再从“验证成功时间”开始按分钟计时。
-- 管理员命令：/trueuuid link <name>
-    - 将该名字对应“离线 UUID”的玩家数据迁移/合并到“正版 UUID”。支持 dry-run 预览与备份。
-- 可靠显示踢出原因（Forge 1.20.x）
-    - 登录阶段显式发送登录/游戏断开包，确保客户端不再只显示“连接中断”，而是展示自定义中文原因。
+## 为什么需要它
+
+离线模式服务器默认无法信任玩家 UUID。TrueUUID 可以在保持服务器离线模式的同时，提高玩家身份一致性。
+
+验证成功的玩家可以继续使用 Mojang 或 Yggdrasil 返回的正式 UUID 和皮肤数据，而服务器不会接触玩家的 access token。
+
+它适合整合包、局域网式服务器、私人离线模式社区，以及希望改善身份一致性但不想直接开启 Mojang 在线模式的服务器。
 
 ## 工作流程
 
-1. 服务器为离线模式。在登录阶段（HELLO），服务器发送自定义登录查询（transactionId + 标识 `trueuuid:auth` + 随机 nonce）。
-2. 客户端拦截该查询，读取 nonce，在本地调用 `MinecraftSessionService.joinServer(profile, token, nonce)`（令牌不出本地）。
-3. 客户端仅回传一个布尔确认（不含敏感数据）。
-4. 服务器调用 Mojang `/hasJoined?username={name}&serverId={nonce}[&ip={ip}]` 进行验证。
-5. 验证成功：
-    - 替换待登录的 `GameProfile` 为正版 UUID 与 Mojang 返回的规范名字。
-    - 注入皮肤 `textures` 属性（含签名）。
-    - 进服后强制刷新玩家信息以更新皮肤。
-    - 显示绿色标题“正版模式”（副标题可配置短语）。
-6. 验证失败：
-    - 默认：
-        - 超时：按配置踢出。
-        - 失败：由下述策略决定（见“配置”）。离线兜底会显示红色标题“离线模式”和聊天说明。
+1. 服务端运行在离线模式。
+2. 玩家登录时，服务端发送带 nonce 的自定义登录查询。
+3. 安装了 Mod 的客户端收到查询后，在本地使用玩家 profile、token 和 nonce 调用 `joinServer`。token 不会离开客户端。
+4. 客户端返回认证结果和选择的认证来源。
+5. 服务端通过 Mojang Session Server 或受支持的 Yggdrasil `hasJoined` 接口验证 nonce。
+6. 如果验证成功：
+   - 将待登录 profile 替换为验证后的 UUID。
+   - 修正玩家名大小写。
+   - 注入带签名的皮肤 textures 属性。
+   - 记录认证来源。
+   - 玩家进入后刷新玩家列表和皮肤信息。
+7. 如果验证失败或超时：
+   - 行为由配置决定。
+   - 已验证过的名字可以禁止离线兜底。
+   - 未知名字可以按配置允许离线兜底。
 
-## 环境需求
+## 离线数据迁移
 
-- Minecraft：1.20.x
-- Forge：47.x（如 47.4.0+）
-- Java：17
-- 客户端与服务端都需安装本模组
-- 服务器需设为 `online-mode=false`
+TrueUUID 1.0.9 增加了更安全的离线数据迁移流程，用于玩家原本使用离线账号游玩，后来改用同名正版账号或皮肤站账号的情况。
 
-## 配置项
+当验证登录时检测到同名离线 UUID 数据，客户端会显示确认迁移窗口。只有玩家确认后才会执行迁移。
 
-首次运行会生成：
-- `config/trueuuid-common.toml`
+迁移前，TrueUUID 会同时备份旧的离线数据，以及目标正版/皮肤站 UUID 已有的数据。
 
-主要键与默认值：
+目前支持迁移的数据包括：
 
-- auth.timeoutMs = 10000
-    - 登录阶段等待客户端回包的时间（毫秒）。
-- auth.allowOfflineOnTimeout = false
-    - false：超时踢出（默认）
-    - true：超时时允许离线兜底
-- auth.allowOfflineOnFailure = true
-    - 旧式总开关；更推荐使用下面更细粒度的新策略。
-- auth.timeoutKickMessage = "登录超时，未完成账号校验"
-    - 超时时展示的踢出原因。
-- auth.offlineFallbackMessage = "注意：你当前以离线模式进入服务器；如果你是正版账号..."
-    - 离线兜底进入时发送的聊天说明。
-- auth.offlineShortSubtitle = "鉴权失败：离线模式"
-    - 离线模式时标题的短副标题。
-- auth.onlineShortSubtitle = "已通过正版校验"
-    - 正版模式时标题的短副标题。
-- auth.knownPremiumDenyOffline = true
-    - 已验证过正版的名字，之后鉴权失败不允许离线兜底（防止分叉）。
-- auth.allowOfflineForUnknownOnly = true
-    - 仅“从未验证为正版”的名字可离线兜底。
-- auth.recentIpGrace.enabled = true
-    - 启用“退出后同 IP 短时重连”容错。
-- auth.recentIpGrace.ttlSeconds = 10
-    - 玩家退出后允许同名同 IP 复用上次验证 UUID 的秒数。有效范围：1–60。命中一次后即消费。
-- auth.yggdrasil.apiRootWhitelist = []
-    - authlib-injector/Yggdrasil 皮肤站 hasJoined URL 白名单。留空表示信任客户端上报的皮肤站端点；可填如 `["littleskin.cn"]`，只允许匹配的皮肤站通过。
+- 原版 `playerdata`
+- 原版 `playerdata_old`
+- 进度 `advancements`
+- 统计 `stats`
+- Cosmetic Armor 的 `.cosarmor` 数据
+- Open Parties and Claims
+- FTB Chunks
+- FTB Essentials
+- FTB Teams
+- FTB Quests
+- FTB Ranks
+- CustomNPCs 玩家数据
 
-说明：
-- 同 IP 容错重在可用性，并非强安全；请保持退出重连窗口很短，公共/共享网络慎用。
-- 旧开关 `allowOfflineOnFailure` 仍有效，但建议优先使用新策略。
+## 环境要求
 
-## 管理命令
+Forge 版本：
 
-- /trueuuid link <name>
-    - 将该名字对应的“离线 UUID”数据迁移到“正版 UUID”（从注册表中读取正版 UUID）。
-    - 子命令示例：
-        - /trueuuid link dryrun <name>  — 预览操作，不写盘
-        - /trueuuid link run <name>     — 执行迁移（示例实现中默认会先备份）
-    - 行为：
-        - 若正版数据文件不存在，则把离线文件“移动”为正版。
-        - 若两者都存在，默认保留正版（合并背包/末影箱/统计可按需实现，已预留 TODO）。
+- Minecraft: 1.20.1
+- Forge: 47.x
+- Java: 17
 
-涉及文件（按 UUID）：
-- world/playerdata/<uuid>.dat
-- world/advancements/<uuid>.json
-- world/stats/<uuid>.json
+NeoForge 版本：
 
-备份目录：
-- world/backups/trueuuid/<时间戳>/<name>/
+- Minecraft: 1.21.1
+- NeoForge: 21.1.x
+- Java: 21
 
-## 故障排查
+客户端和服务端必须都安装 TrueUUID。
 
-- 客户端只显示“连接中断”而非自定义原因：
-    - 在 Forge 47.4.x 的登录/配置握手阶段可能存在并行。服务端已在登录阶段显式发送“登录断开包 + 游戏断开包”后再断开，通常可正确展示原因。若仍无效，请用“纯净客户端”（无 UI 改造模组）测试。
+## 安装
 
-- 皮肤未及时刷新：
-    - 服务端会在玩家进服后一帧广播 PlayerInfo 刷新。若客户端有改造皮肤的模组，请确保不拦截原版刷新。
+服务端：
 
-## 兼容与注意
+1. 在 `server.properties` 中设置 `online-mode=false`。
+2. 将对应版本的 TrueUUID jar 放入服务端 `mods` 文件夹。
 
-- 代理（Bungee/Velocity）：若能获取真实 IP，会将其带入 `/hasJoined`；即使没有 IP 参数也能正常验证（IP 对 Mojang 接口是可选）。
-- 数据一致性：结合“已知正版名禁止离线 + 仅未知名可离线”，可有效避免“同名不同 UUID”与存档分叉。
-- 若客户端未安装本模组：将无法回传预期负载，具体行为由配置/策略决定（可能踢出或仅允许未知新名字离线）。
+客户端：
+
+1. 将对应版本的 TrueUUID jar 放入客户端 `mods` 文件夹。
+
+如果客户端没有安装本 Mod，服务端将收不到预期的登录查询响应。根据配置不同，该玩家可能会被踢出，也可能会进入离线兜底流程。
+
+## 配置
+
+首次运行后会生成配置文件：
+
+```text
+config/trueuuid-common.toml
+```
+
+常用配置：
+
+```toml
+auth.timeoutMs = 30000
+```
+
+登录阶段等待客户端认证响应的时间，单位为毫秒。
+
+```toml
+auth.allowOfflineOnTimeout = false
+```
+
+`false`：认证超时后踢出。
+
+`true`：认证超时后允许离线兜底。
+
+```toml
+auth.allowOfflineOnFailure = true
+```
+
+`true`：普通认证失败时允许进入离线兜底流程。
+
+`false`：认证失败时直接断开连接。
+
+```toml
+auth.knownPremiumDenyOffline = true
+```
+
+如果某个名字已经成功验证为正版或 Yggdrasil 账号，后续不允许该名字再通过离线兜底进入。
+
+```toml
+auth.allowOfflineForUnknownOnly = true
+```
+
+只允许从未验证过的名字使用离线兜底。
+
+```toml
+auth.recentIpGrace.enabled = true
+auth.recentIpGrace.ttlSeconds = 10
+```
+
+允许已验证玩家退出后，在短时间内使用同名同 IP 重连时复用上一次验证 UUID。该机制不会用于明确拒绝认证或明确离线登录的客户端。
+
+```toml
+auth.nomojang.enabled = false
+```
+
+开启后会禁用 Mojang 会话校验。通常不建议开启。
+
+```toml
+auth.yggdrasil.apiRootWhitelist = []
+```
+
+Yggdrasil/authlib-injector `hasJoined` URL 白名单。空列表表示信任客户端上报的接口地址。可以添加 `"littleskin.cn"` 等条目来限制允许的皮肤站来源。
+
+NeoForge 1.21.1 额外提供：
+
+```toml
+auth.mojangReverseProxy = "https://sessionserver.mojang.com"
+```
+
+Mojang Session Server 地址。如有需要，可以改为反代地址。
+
+## 兼容性说明
+
+- 代理服：Mojang `hasJoined` 的 IP 参数是可选项。即使代理隐藏了真实客户端 IP，通常仍可完成验证。
+- 皮肤：TrueUUID 会在登录阶段注入带签名的皮肤属性，并在玩家进服后刷新玩家信息。如果客户端仍显示旧皮肤，可以尝试重新进服或清理皮肤缓存。
+- 离线兜底：离线兜底行为可配置。推荐配置下，已经验证过的名字不能再被离线客户端复用。
+- 注册表：TrueUUID 会把已验证过的名字记录在 `trueuuid-registry.json`。如果清空该文件，服务端会忘记之前的正版/Yggdrasil 绑定记录。
 
 ## 构建
 
-- 克隆仓库
-- 执行：
-    - Windows：`gradlew.bat build`
-    - macOS/Linux：`./gradlew build`
-- 成品在：`build/libs/trueuuid-<version>.jar`
+Windows：
+
+```powershell
+.\gradlew.bat build
+```
+
+macOS/Linux：
+
+```bash
+./gradlew build
+```
+
+构建产物会输出到 `build/libs/`。
 
 ## 隐私
 
-- 访问令牌仅在客户端本地使用，不会发送至服务器。
-- 服务器仅收到布尔确认，随后自行请求 Mojang Session Server 完成校验。
+玩家 access token 永远不会发送给服务器。
 
-## 许可
+客户端只在本地使用 token 调用 `joinServer`。服务端只接收认证结果，并自行通过 Mojang Session Server 或受支持的 Yggdrasil 接口验证 nonce。
 
-- GNU LGPL 3.0（详见 `gradle.properties` / 仓库 License）
+## 许可证
+
+GNU LGPL 3.0
 
 ## 致谢
 
-- Mojang authlib 与 session API
+- Mojang authlib and session API
 - Sponge Mixin
 - ForgeGradle
+- NeoForge / ModDevGradle
 
 ---
-维护者: [@YuWan-030](https://github.com/YuWan-030)
+
+维护者：[@YuWan-030](https://github.com/YuWan-030)

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ mod_name=TrueUUID
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU LGPL 3.0
 # The mod version. See https://semver.org/
-mod_version=1.0.8
+mod_version=1.0.9
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/cn/alini/trueuuid/mixin/client/ClientHandshakeMixin.java
+++ b/src/main/java/cn/alini/trueuuid/mixin/client/ClientHandshakeMixin.java
@@ -3,6 +3,7 @@ package cn.alini.trueuuid.mixin.client;
 import cn.alini.trueuuid.net.NetIds;
 import io.netty.buffer.Unpooled;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.ConfirmScreen;
 import net.minecraft.client.User; // official 映射 (mapping)
 import net.minecraft.client.multiplayer.ClientHandshakePacketListenerImpl;
 import net.minecraft.network.Connection;
@@ -36,6 +37,22 @@ public abstract class ClientHandshakeMixin {
 
         FriendlyByteBuf buf = packet.getData();
         String serverId = buf.readUtf();
+        boolean offlineUpgradeAvailable = false;
+        String offlineUuid = "";
+        String offlineDataSummary = "";
+        try {
+            if (buf.isReadable()) {
+                offlineUpgradeAvailable = buf.readBoolean();
+                if (offlineUpgradeAvailable) {
+                    offlineUuid = buf.readUtf();
+                    offlineDataSummary = buf.readUtf();
+                }
+            }
+        } catch (Throwable ignored) {
+            offlineUpgradeAvailable = false;
+            offlineUuid = "";
+            offlineDataSummary = "";
+        }
 
         Minecraft mc = Minecraft.getInstance();
         User user = mc.getUser();
@@ -46,13 +63,16 @@ public abstract class ClientHandshakeMixin {
 
         // dev/离线启动常见的占位 token 不可能通过 Mojang 校验，立即回失败，避免登录线程等到服务器超时。
         if (trueuuid$isMissingSessionToken(token)) {
-            trueuuid$sendAuthAck(loginConnection, transactionId, false, "");
+            trueuuid$sendAuthAck(loginConnection, transactionId, false, "", false, true);
             ci.cancel();
             return;
         }
 
         // 在调用 joinServer 之前先读取 CHECK_URL，因为 joinServer 是一次性的。
         String hasJoinedUrl = trueuuid$resolveHasJoinedUrl();
+        final boolean upgradeAvailable = offlineUpgradeAvailable;
+        final String upgradeOfflineUuid = offlineUuid;
+        final String upgradeDataSummary = offlineDataSummary;
 
         // 复用原版正版登录文案，中文客户端会显示"正在登录中..."。
         this.updateStatus.accept(Component.translatable("connect.authorizing"));
@@ -69,7 +89,13 @@ public abstract class ClientHandshakeMixin {
                 })
                 .orTimeout(30, TimeUnit.SECONDS)
                 .exceptionally(t -> false)
-                .thenAccept(ok -> trueuuid$sendAuthAck(loginConnection, transactionId, ok, hasJoinedUrl));
+                .thenAccept(ok -> {
+                    if (!ok || !upgradeAvailable) {
+                        trueuuid$sendAuthAck(loginConnection, transactionId, ok, hasJoinedUrl, false, false);
+                        return;
+                    }
+                    trueuuid$confirmOfflinePlayerDataUpgrade(mc, upgradeOfflineUuid, upgradeDataSummary, hasJoinedUrl, loginConnection, transactionId);
+                });
 
         ci.cancel();
     }
@@ -81,13 +107,65 @@ public abstract class ClientHandshakeMixin {
     }
 
     @Unique
-    private static void trueuuid$sendAuthAck(Connection connection, int transactionId, boolean ok, String hasJoinedUrl) {
+    private static void trueuuid$sendAuthAck(Connection connection, int transactionId, boolean ok, String hasJoinedUrl, boolean migrationConfirmed, boolean missingSessionToken) {
         // LOGIN 自定义查询必须回复 LOGIN 阶段的 ServerboundCustomQueryPacket，不能切到 PLAY 包。
         FriendlyByteBuf resp = new FriendlyByteBuf(Unpooled.buffer());
         resp.writeBoolean(ok);
         // 附带 hasJoined URL：空字符串表示使用 Mojang 默认。
         resp.writeUtf(hasJoinedUrl != null ? hasJoinedUrl : "");
+        resp.writeBoolean(migrationConfirmed);
+        resp.writeBoolean(missingSessionToken);
         connection.send(new ServerboundCustomQueryPacket(transactionId, resp));
+    }
+
+    @Unique
+    private static void trueuuid$confirmOfflinePlayerDataUpgrade(Minecraft mc, String offlineUuid, String offlineDataSummary, String hasJoinedUrl, Connection connection, int transactionId) {
+        mc.execute(() -> {
+            String mode = hasJoinedUrl == null || hasJoinedUrl.isBlank() ? "正版验证" : "皮肤站登录";
+            Component title = Component.literal("确认迁移离线玩家数据");
+            Component message = Component.literal(
+                    "检测到同名离线玩家数据。\n\n"
+                            + "当前登录方式: " + mode + "\n"
+                            + "离线 UUID: " + offlineUuid + "\n"
+                            + "可迁移数据: " + offlineDataSummary + "\n\n"
+                            + "继续进入会先备份离线玩家数据，再迁移到当前账号。迁移后该名称会绑定当前账号。"
+            );
+            mc.setScreen(new ConfirmScreen(
+                    confirmed -> {
+                        trueuuid$sendAuthAck(connection, transactionId, true, hasJoinedUrl, confirmed, false);
+                        mc.setScreen(null);
+                    },
+                    title,
+                    message,
+                    Component.literal("确认迁移数据并进入"),
+                    Component.literal("取消进入")
+            ));
+        });
+    }
+
+    @Unique
+    private static void trueuuid$confirmOfflineUpgrade(Minecraft mc, String offlineUuid, String offlineDataSummary, String hasJoinedUrl, Connection connection, int transactionId) {
+        mc.execute(() -> {
+            String mode = hasJoinedUrl == null || hasJoinedUrl.isBlank() ? "正版验证" : "皮肤站登录";
+            Component title = Component.literal("确认迁移离线存档");
+            Component message = Component.literal(
+                    "检测到同名离线存档。\n\n"
+                            + "当前登录方式: " + mode + "\n"
+                            + "离线 UUID: " + offlineUuid + "\n"
+                            + "可迁移数据: " + offlineDataSummary + "\n\n"
+                            + "继续进入会先备份离线存档，再迁移到当前账号。迁移后该名称会绑定当前账号。"
+            );
+            mc.setScreen(new ConfirmScreen(
+                    confirmed -> {
+                        trueuuid$sendAuthAck(connection, transactionId, true, hasJoinedUrl, confirmed, false);
+                        mc.setScreen(null);
+                    },
+                    title,
+                    message,
+                    Component.literal("确认迁移并进入"),
+                    Component.literal("取消进入")
+            ));
+        });
     }
 
     /**

--- a/src/main/java/cn/alini/trueuuid/mixin/server/ServerLoginMixin.java
+++ b/src/main/java/cn/alini/trueuuid/mixin/server/ServerLoginMixin.java
@@ -39,6 +39,8 @@ public abstract class ServerLoginMixin {
     @Unique private int trueuuid$txId = 0;
     @Unique private String trueuuid$nonce = null;
     @Unique private long trueuuid$sentAt = 0L;
+    @Unique private boolean trueuuid$offlineUpgradeOffered = false;
+    @Unique private static final java.util.concurrent.ConcurrentHashMap<String, Long> TRUEUUID$MIGRATION_PENDING = new java.util.concurrent.ConcurrentHashMap<>();
 
 
     // 新增：防止重复处理客户端认证包（同次握手只处理一次）(Added: Prevent duplicate processing of client auth packets (only process once per handshake))
@@ -104,8 +106,24 @@ public abstract class ServerLoginMixin {
             System.out.println("[TrueUUID] 握手 nonce: " + this.trueuuid$nonce + ", txId: " + this.trueuuid$txId);
         }
 
+        PlayerDataMigration.OfflineData offlineData = null;
+        if (this.gameProfile != null && !TrueuuidRuntime.NAME_REGISTRY.isKnownPremiumName(this.gameProfile.getName())) {
+            offlineData = PlayerDataMigration.findOfflineData(this.server, this.gameProfile.getName());
+        }
+        if (offlineData != null && this.gameProfile != null && trueuuid$isMigrationPending(this.gameProfile.getName())) {
+            sendDisconnectWithReason(Component.literal("离线玩家数据迁移正在完成，请稍后重新进入。"));
+            reset();
+            return;
+        }
+        this.trueuuid$offlineUpgradeOffered = offlineData != null;
+
         FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
         buf.writeUtf(this.trueuuid$nonce);
+        buf.writeBoolean(offlineData != null);
+        if (offlineData != null) {
+            buf.writeUtf(offlineData.offlineUuid().toString());
+            buf.writeUtf(offlineData.summary());
+        }
 
         this.connection.send(new ClientboundCustomQueryPacket(this.trueuuid$txId, NetIds.AUTH, buf));
     }
@@ -113,7 +131,7 @@ public abstract class ServerLoginMixin {
     @Inject(method = "tick", at = @At("HEAD"), cancellable = true)
     private void trueuuid$onTick(CallbackInfo ci) {
         if (this.trueuuid$txId == 0 || this.trueuuid$sentAt == 0L) return;
-        long timeoutMs = TrueuuidConfig.timeoutMs();
+        long timeoutMs = this.trueuuid$offlineUpgradeOffered ? Math.max(TrueuuidConfig.timeoutMs(), 180_000L) : TrueuuidConfig.timeoutMs();
         if (timeoutMs <= 0) {
             // TrueUUID 自定义认证还没有结束时暂停原版登录推进，避免离线档案先进入世界后又被正版档案二次接受。
             ci.cancel();
@@ -131,7 +149,10 @@ public abstract class ServerLoginMixin {
             System.out.println("[TrueUUID] 握手超时, txId: " + this.trueuuid$txId);
         }
 
-        if (TrueuuidConfig.allowOfflineOnTimeout()) {
+        if (this.trueuuid$offlineUpgradeOffered) {
+            sendDisconnectWithReason(Component.literal("离线玩家数据迁移确认超时，未修改任何玩家数据。请重新进入并确认。"));
+            reset();
+        } else if (TrueuuidConfig.allowOfflineOnTimeout()) {
             if (TrueuuidConfig.debug()) {
                 System.out.println("[TrueUUID] 超时允许离线进入");
             }
@@ -182,6 +203,28 @@ public abstract class ServerLoginMixin {
             }
         } catch (Throwable ignored) {}
 
+        boolean migrationConfirmed = false;
+        try {
+            if (data.isReadable()) {
+                migrationConfirmed = data.readBoolean();
+            }
+        } catch (Throwable ignored) {}
+        final boolean finalMigrationConfirmed = migrationConfirmed;
+        if (finalMigrationConfirmed && this.gameProfile != null) {
+            trueuuid$markMigrationPending(this.gameProfile.getName());
+        }
+
+        boolean missingSessionToken = false;
+        try {
+            if (data.isReadable()) {
+                missingSessionToken = data.readBoolean();
+            }
+        } catch (Throwable ignored) {}
+        if (TrueuuidConfig.debug()) {
+            System.out.println("[TrueUUID] auth answer flags: migrationConfirmed=" + finalMigrationConfirmed
+                    + ", missingSessionToken=" + missingSessionToken);
+        }
+
         if (TrueuuidConfig.debug()) {
             System.out.println("[TrueUUID] 客户端认证包ackOk: " + ackOk + ", hasJoinedUrl: " + (clientHasJoinedUrl.isEmpty() ? "(mojang default)" : clientHasJoinedUrl));
         }
@@ -189,7 +232,7 @@ public abstract class ServerLoginMixin {
             if (TrueuuidConfig.debug()) {
                 System.out.println("[TrueUUID] 认证失败, 玩家: " + (this.gameProfile != null ? this.gameProfile.getName() : "<unknown>") + ", ip: " + ip + ", 原因: 客户端拒绝");
             }
-            handleAuthFailure(ip, "客户端拒绝");
+            handleAuthFailure(ip, "客户端拒绝", true);
             reset(); ci.cancel(); return;
         }
 
@@ -208,7 +251,7 @@ public abstract class ServerLoginMixin {
                     if (TrueuuidConfig.debug()) {
                         System.out.println("[TrueUUID] 客户端上报的 hasJoined URL 不在白名单中: " + clientHasJoinedUrl);
                     }
-                    handleAuthFailure(ip, "不受信任的认证服务器");
+            handleAuthFailure(ip, "不受信任的认证服务器", false);
                     reset(); ci.cancel(); return;
                 }
             }
@@ -232,6 +275,15 @@ public abstract class ServerLoginMixin {
             ci.cancel();
 
             SessionCheck.hasJoinedAsync(this.gameProfile.getName(), this.trueuuid$nonce, ip, hasJoinedUrl)
+                    .thenCompose(resOpt -> {
+                        if (resOpt.isPresent() || !hasJoinedUrl.isEmpty() || !trueuuid$isLocalAddress(ip)) {
+                            return java.util.concurrent.CompletableFuture.completedFuture(resOpt);
+                        }
+                        if (TrueuuidConfig.debug()) {
+                            System.out.println("[TrueUUID] Mojang hasJoined failed for local connection; trying signed Mojang profile fallback, player=" + this.gameProfile.getName() + ", ip=" + ip);
+                        }
+                        return SessionCheck.lookupMojangProfileAsync(this.gameProfile.getName());
+                    })
                     .whenComplete((resOpt, throwable) -> {
                         // 始终在主线程处理后续逻辑 (Always process subsequent logic on main thread)
                         server.execute(() -> {
@@ -240,7 +292,7 @@ public abstract class ServerLoginMixin {
                                     if (TrueuuidConfig.debug()) {
                                         System.out.println("[TrueUUID] 认证异步回调发生异常: " + throwable);
                                     }
-                                    handleAuthFailure(ip, "服务器异常");
+                                    handleAuthFailure(ip, "服务器异常", false);
                                     return;
                                 }
 
@@ -248,7 +300,7 @@ public abstract class ServerLoginMixin {
                                     if (TrueuuidConfig.debug()) {
                                         System.out.println("[TrueUUID] 认证失败, 玩家: " + (this.gameProfile != null ? this.gameProfile.getName() : "<unknown>") + ", ip: " + ip + ", 原因: 会话无效");
                                     }
-                                    handleAuthFailure(ip, "会话无效");
+                                    handleAuthFailure(ip, "会话无效", false);
                                     return;
                                 }
 
@@ -259,9 +311,6 @@ public abstract class ServerLoginMixin {
                                         ? AuthState.AuthSource.MOJANG
                                         : AuthState.AuthSource.YGGDRASIL;
                                 String displayName = trueuuid$authDisplayName(hasJoinedUrl);
-
-                                TrueuuidRuntime.NAME_REGISTRY.recordSuccess(res.name(), res.uuid(), ip, source, displayName);
-                                TrueuuidRuntime.IP_GRACE.record(res.name(), ip, res.uuid(), source, displayName);
 
                                 GameProfile newProfile = new GameProfile(res.uuid(), res.name());
                                 var propMap = newProfile.getProperties();
@@ -275,6 +324,11 @@ public abstract class ServerLoginMixin {
                                 }
                                 this.gameProfile = newProfile;
                                 AuthState.markAuthSuccess(this.connection, res.uuid(), res.name(), source, displayName);
+                                if (!trueuuid$handleOfflineUpgradeIfNeeded(res.name(), res.uuid(), source, displayName, finalMigrationConfirmed)) {
+                                    return;
+                                }
+                                TrueuuidRuntime.NAME_REGISTRY.recordSuccess(res.name(), res.uuid(), ip, source, displayName);
+                                TrueuuidRuntime.IP_GRACE.record(res.name(), ip, res.uuid(), source, displayName);
                                 if (TrueuuidConfig.debug()) {
                                     System.out.println("[TrueUUID] 记录认证成功来源: " + source + ", displayName=" + displayName);
                                 }
@@ -283,8 +337,11 @@ public abstract class ServerLoginMixin {
                                 if (TrueuuidConfig.debug()) {
                                     System.out.println("[TrueUUID] 认证异步处理时发生异常: " + t);
                                 }
-                                handleAuthFailure(ip, "服务器异常");
+                                handleAuthFailure(ip, "服务器异常", false);
                             } finally {
+                                if (this.gameProfile != null) {
+                                    trueuuid$clearMigrationPending(this.gameProfile.getName());
+                                }
                                 reset();
                             }
                         });
@@ -296,7 +353,7 @@ public abstract class ServerLoginMixin {
             if (TrueuuidConfig.debug()) {
                 System.out.println("[TrueUUID] 启动异步认证时出错: " + t);
             }
-            handleAuthFailure(ip, "服务器异常");
+            handleAuthFailure(ip, "服务器异常", false);
             reset();
             this.trueuuid$ackHandled = false;
         }
@@ -304,12 +361,17 @@ public abstract class ServerLoginMixin {
 
     @Unique
     private void handleAuthFailure(String ip, String why) {
+        handleAuthFailure(ip, why, false);
+    }
+
+    @Unique
+    private void handleAuthFailure(String ip, String why, boolean explicitOfflineClient) {
         String name = this.gameProfile != null ? this.gameProfile.getName() : "<unknown>";
         System.out.println("[TrueUUID] 认证失败, 玩家: " + name + ", ip: " + ip + ", 原因: " + why);
         if (TrueuuidConfig.debug()) {
             System.out.println("[TrueUUID] 会话无效, 玩家: " + name + ", ip: " + ip + ", 失败原因: " + why);
         }
-        AuthDecider.Decision d = AuthDecider.onFailure(name, ip);
+        AuthDecider.Decision d = AuthDecider.onFailure(name, ip, explicitOfflineClient);
 
         switch (d.kind) {
             case PREMIUM_GRACE -> {
@@ -367,6 +429,85 @@ public abstract class ServerLoginMixin {
     }
 
     @Unique
+    private static boolean trueuuid$isLocalAddress(String ip) {
+        if (ip == null || ip.isBlank()) {
+            return false;
+        }
+        return "127.0.0.1".equals(ip)
+                || "0:0:0:0:0:0:0:1".equals(ip)
+                || "::1".equals(ip)
+                || "localhost".equalsIgnoreCase(ip);
+    }
+
+    @Unique
+    private static void trueuuid$markMigrationPending(String name) {
+        if (name == null || name.isBlank()) return;
+        TRUEUUID$MIGRATION_PENDING.put(name.toLowerCase(java.util.Locale.ROOT), System.currentTimeMillis());
+    }
+
+    @Unique
+    private static void trueuuid$clearMigrationPending(String name) {
+        if (name == null || name.isBlank()) return;
+        TRUEUUID$MIGRATION_PENDING.remove(name.toLowerCase(java.util.Locale.ROOT));
+    }
+
+    @Unique
+    private static boolean trueuuid$isMigrationPending(String name) {
+        if (name == null || name.isBlank()) return false;
+        String key = name.toLowerCase(java.util.Locale.ROOT);
+        Long since = TRUEUUID$MIGRATION_PENDING.get(key);
+        if (since == null) return false;
+        if (System.currentTimeMillis() - since > 30_000L) {
+            TRUEUUID$MIGRATION_PENDING.remove(key, since);
+            return false;
+        }
+        return true;
+    }
+
+    @Unique
+    private boolean trueuuid$handleOfflineUpgradeIfNeeded(String name, UUID verifiedUuid, AuthState.AuthSource source, String displayName, boolean confirmed) {
+        if (!PlayerDataMigration.needsOfflineUpgrade(this.server, name, verifiedUuid)) {
+            return true;
+        }
+        PlayerDataMigration.OfflineData data = PlayerDataMigration.findOfflineData(this.server, name);
+        if (data == null) {
+            return true;
+        }
+        if (!confirmed) {
+            String sourceName = source == AuthState.AuthSource.YGGDRASIL
+                    ? (displayName == null || displayName.isBlank() ? "皮肤站登录" : "皮肤站登录(" + displayName + ")")
+                    : "正版验证";
+            sendDisconnectWithReason(Component.literal(
+                    "检测到同名离线玩家数据，但你取消了迁移。\n\n"
+                            + "当前登录方式: " + sourceName + "\n"
+                            + "离线 UUID: " + data.offlineUuid() + "\n"
+                            + "当前 UUID: " + verifiedUuid + "\n\n"
+                            + "未迁移前不会修改任何玩家数据。"
+            ));
+            return false;
+        }
+        try {
+            PlayerDataMigration.migrateOfflineToVerified(this.server, name, verifiedUuid);
+            if (TrueuuidConfig.debug()) {
+                System.out.println("[TrueUUID] migrated offline data before login: player=" + name
+                        + ", offlineUuid=" + data.offlineUuid() + ", verifiedUuid=" + verifiedUuid);
+            }
+            return true;
+        } catch (Exception ex) {
+            System.out.println("[TrueUUID] 离线玩家数据迁移失败, player=" + name + ", offlineUuid=" + data.offlineUuid()
+                    + ", verifiedUuid=" + verifiedUuid + ", error=" + ex);
+            sendDisconnectWithReason(Component.literal(
+                    "离线玩家数据迁移失败，已取消进入以避免数据错乱。\n\n"
+                            + "玩家: " + name + "\n"
+                            + "离线 UUID: " + data.offlineUuid() + "\n"
+                            + "当前 UUID: " + verifiedUuid + "\n\n"
+                            + "原因: " + ex.getMessage()
+            ));
+            return false;
+        }
+    }
+
+    @Unique
     private void reset() {
         if (TrueuuidConfig.debug()) {
             System.out.println("[TrueUUID] 状态重置, txId: " + this.trueuuid$txId);
@@ -374,5 +515,6 @@ public abstract class ServerLoginMixin {
         this.trueuuid$txId = 0;
         this.trueuuid$nonce = null;
         this.trueuuid$sentAt = 0L;
+        this.trueuuid$offlineUpgradeOffered = false;
     }
 }

--- a/src/main/java/cn/alini/trueuuid/server/AuthDecider.java
+++ b/src/main/java/cn/alini/trueuuid/server/AuthDecider.java
@@ -17,6 +17,10 @@ public final class AuthDecider {
     }
 
     public static Decision onFailure(String name, String ip) {
+        return onFailure(name, ip, false);
+    }
+
+    public static Decision onFailure(String name, String ip, boolean explicitOfflineClient) {
         Decision d = new Decision();
 
         boolean known = TrueuuidRuntime.NAME_REGISTRY.isKnownPremiumName(name);
@@ -24,7 +28,7 @@ public final class AuthDecider {
         // Velocity/VC proxy compatibility: if the modded client answered the
         // trueuuid:auth query but Mojang hasJoined still fails behind a local
         // proxy, preserve the already-bound premium UUID instead of denying.
-        if (known && isLocalProxyAddress(ip)) {
+        if (known && !explicitOfflineClient && isLocalProxyAddress(ip)) {
             Optional<UUID> premiumUuid = TrueuuidRuntime.NAME_REGISTRY.getPremiumUuid(name);
             if (premiumUuid.isPresent()) {
                 d.kind = Decision.Kind.PREMIUM_GRACE;
@@ -38,7 +42,7 @@ public final class AuthDecider {
         // 1) 近期同 IP 成功容错：临时按正版处理。
         // 必须优先于 knownPremiumDenyOffline，否则“刚刚成功验证过的正版名”在 Mojang 短暂失败时会被直接拒绝，
         // 配置里的 recentIpGrace.enabled/ttlSeconds 就失去意义。
-        if (TrueuuidConfig.recentIpGraceEnabled()) {
+        if (TrueuuidConfig.recentIpGraceEnabled() && !explicitOfflineClient) {
             Optional<RecentIpGraceCache.GraceResult> p = TrueuuidRuntime.IP_GRACE.tryGraceResult(name, ip, TrueuuidConfig.recentIpGraceTtlSeconds());
             if (p.isPresent()) {
                 d.kind = Decision.Kind.PREMIUM_GRACE;

--- a/src/main/java/cn/alini/trueuuid/server/PlayerDataMigration.java
+++ b/src/main/java/cn/alini/trueuuid/server/PlayerDataMigration.java
@@ -1,0 +1,199 @@
+package cn.alini.trueuuid.server;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.storage.LevelResource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+public final class PlayerDataMigration {
+    public record OfflineData(UUID offlineUuid, String summary) {}
+
+    private static final DateTimeFormatter BACKUP_TIME = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
+
+    public static UUID offlineUuid(String name) {
+        return UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static OfflineData findOfflineData(MinecraftServer server, String name) {
+        UUID offlineUuid = offlineUuid(name);
+        List<String> found = new ArrayList<>();
+        if (Files.exists(playerData(server, offlineUuid))) found.add("playerdata");
+        if (Files.exists(playerDataOld(server, offlineUuid))) found.add("playerdata_old");
+        if (Files.exists(cosmeticArmor(server, offlineUuid))) found.add("Cosmetic Armor");
+        if (Files.exists(advancements(server, offlineUuid))) found.add("advancements");
+        if (Files.exists(stats(server, offlineUuid))) found.add("stats");
+        if (Files.exists(opacPlayerClaims(server, offlineUuid)) || Files.exists(opacPlayerConfig(server, offlineUuid))) {
+            found.add("Open Parties and Claims");
+        }
+        if (Files.exists(ftbChunksPlayer(server, offlineUuid))) found.add("FTB Chunks");
+        if (Files.exists(ftbEssentialsPlayer(server, offlineUuid))) found.add("FTB Essentials");
+        if (Files.exists(ftbTeamsPlayer(server, offlineUuid))) found.add("FTB Teams");
+        if (Files.exists(ftbQuestsPlayer(server, offlineUuid))) found.add("FTB Quests");
+        if (Files.exists(customNpcsPlayer(server, offlineUuid))) found.add("CustomNPCs");
+        if (containsUuid(ftbRanksPlayers(server), offlineUuid)) found.add("FTB Ranks");
+        if (found.isEmpty()) return null;
+        return new OfflineData(offlineUuid, String.join(", ", found));
+    }
+
+    public static boolean needsOfflineUpgrade(MinecraftServer server, String name, UUID verifiedUuid) {
+        OfflineData data = findOfflineData(server, name);
+        return data != null && verifiedUuid != null && !data.offlineUuid().equals(verifiedUuid);
+    }
+
+    public static void migrateOfflineToVerified(MinecraftServer server, String name, UUID verifiedUuid) throws IOException {
+        OfflineData data = findOfflineData(server, name);
+        if (data == null || verifiedUuid == null || data.offlineUuid().equals(verifiedUuid)) {
+            return;
+        }
+
+        List<FilePair> pairs = List.of(
+                new FilePair(playerData(server, data.offlineUuid()), playerData(server, verifiedUuid), false, "vanilla"),
+                new FilePair(playerDataOld(server, data.offlineUuid()), playerDataOld(server, verifiedUuid), false, "vanilla"),
+                new FilePair(cosmeticArmor(server, data.offlineUuid()), cosmeticArmor(server, verifiedUuid), false, "cosarmor"),
+                new FilePair(advancements(server, data.offlineUuid()), advancements(server, verifiedUuid), false, "vanilla"),
+                new FilePair(stats(server, data.offlineUuid()), stats(server, verifiedUuid), false, "vanilla"),
+                new FilePair(opacPlayerClaims(server, data.offlineUuid()), opacPlayerClaims(server, verifiedUuid), false, "opac"),
+                new FilePair(opacPlayerConfig(server, data.offlineUuid()), opacPlayerConfig(server, verifiedUuid), true, "opac"),
+                new FilePair(ftbChunksPlayer(server, data.offlineUuid()), ftbChunksPlayer(server, verifiedUuid), true, "ftbchunks"),
+                new FilePair(ftbEssentialsPlayer(server, data.offlineUuid()), ftbEssentialsPlayer(server, verifiedUuid), true, "ftbessentials"),
+                new FilePair(ftbTeamsPlayer(server, data.offlineUuid()), ftbTeamsPlayer(server, verifiedUuid), true, "ftbteams"),
+                new FilePair(ftbQuestsPlayer(server, data.offlineUuid()), ftbQuestsPlayer(server, verifiedUuid), true, "ftbquests"),
+                new FilePair(customNpcsPlayer(server, data.offlineUuid()), customNpcsPlayer(server, verifiedUuid), true, "customnpcs")
+        );
+
+        Path backupDir = backupDir(server, name, data.offlineUuid(), verifiedUuid);
+        Files.createDirectories(backupDir);
+
+        for (FilePair pair : pairs) {
+            if (!Files.exists(pair.from())) continue;
+            Files.createDirectories(pair.to().getParent());
+            backupFile(pair.from(), backupDir.resolve("offline").resolve(pair.backupGroup()).resolve(pair.from().getFileName()));
+            if (Files.exists(pair.to())) {
+                backupFile(pair.to(), backupDir.resolve("verified-existing").resolve(pair.backupGroup()).resolve(pair.to().getFileName()));
+            }
+            if (pair.replaceUuidText()) {
+                String text = Files.readString(pair.from(), StandardCharsets.UTF_8);
+                text = replaceUuidText(text, data.offlineUuid(), verifiedUuid);
+                Files.writeString(pair.to(), text, StandardCharsets.UTF_8);
+            } else {
+                Files.copy(pair.from(), pair.to(), StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+
+        replaceGlobalTextFile(ftbRanksPlayers(server), data.offlineUuid(), verifiedUuid, backupDir.resolve("ftbranks").resolve("players.snbt"));
+    }
+
+    private static void replaceGlobalTextFile(Path file, UUID from, UUID to, Path backup) throws IOException {
+        if (!containsUuid(file, from)) return;
+        backupFile(file, backup);
+        String text = Files.readString(file, StandardCharsets.UTF_8);
+        Files.writeString(file, replaceUuidText(text, from, to), StandardCharsets.UTF_8);
+    }
+
+    private static void backupFile(Path source, Path backup) throws IOException {
+        Files.createDirectories(backup.getParent());
+        Files.copy(source, backup, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private static boolean containsUuid(Path file, UUID uuid) {
+        if (!Files.exists(file) || uuid == null) return false;
+        try {
+            String text = Files.readString(file, StandardCharsets.UTF_8);
+            String hyphen = uuid.toString();
+            return text.contains(hyphen) || text.contains(hyphen.replace("-", ""));
+        } catch (IOException ignored) {
+            return false;
+        }
+    }
+
+    private static Path playerData(MinecraftServer server, UUID uuid) {
+        return server.getWorldPath(LevelResource.PLAYER_DATA_DIR).resolve(uuid + ".dat");
+    }
+
+    private static Path playerDataOld(MinecraftServer server, UUID uuid) {
+        return server.getWorldPath(LevelResource.PLAYER_DATA_DIR).resolve(uuid + ".dat_old");
+    }
+
+    private static Path cosmeticArmor(MinecraftServer server, UUID uuid) {
+        return server.getWorldPath(LevelResource.PLAYER_DATA_DIR).resolve(uuid + ".cosarmor");
+    }
+
+    private static Path advancements(MinecraftServer server, UUID uuid) {
+        return server.getWorldPath(LevelResource.PLAYER_ADVANCEMENTS_DIR).resolve(uuid + ".json");
+    }
+
+    private static Path stats(MinecraftServer server, UUID uuid) {
+        return server.getWorldPath(LevelResource.PLAYER_STATS_DIR).resolve(uuid + ".json");
+    }
+
+    private static Path opacPlayerClaims(MinecraftServer server, UUID uuid) {
+        return server.getWorldPath(LevelResource.ROOT)
+                .resolve("data")
+                .resolve("openpartiesandclaims")
+                .resolve("player-claims")
+                .resolve(uuid + ".nbt");
+    }
+
+    private static Path opacPlayerConfig(MinecraftServer server, UUID uuid) {
+        return server.getWorldPath(LevelResource.ROOT)
+                .resolve("data")
+                .resolve("openpartiesandclaims")
+                .resolve("player-configs")
+                .resolve(uuid + ".toml");
+    }
+
+    private static Path ftbChunksPlayer(MinecraftServer server, UUID uuid) {
+        return server.getWorldPath(LevelResource.ROOT).resolve("ftbchunks").resolve(uuid + ".snbt");
+    }
+
+    private static Path ftbEssentialsPlayer(MinecraftServer server, UUID uuid) {
+        return server.getWorldPath(LevelResource.ROOT).resolve("ftbessentials").resolve("playerdata").resolve(uuid + ".snbt");
+    }
+
+    private static Path ftbTeamsPlayer(MinecraftServer server, UUID uuid) {
+        return server.getWorldPath(LevelResource.ROOT).resolve("ftbteams").resolve("player").resolve(uuid + ".snbt");
+    }
+
+    private static Path ftbQuestsPlayer(MinecraftServer server, UUID uuid) {
+        return server.getWorldPath(LevelResource.ROOT).resolve("ftbquests").resolve(uuid + ".snbt");
+    }
+
+    private static Path customNpcsPlayer(MinecraftServer server, UUID uuid) {
+        return server.getWorldPath(LevelResource.ROOT).resolve("customnpcs").resolve("playerdata").resolve(uuid + ".json");
+    }
+
+    private static Path ftbRanksPlayers(MinecraftServer server) {
+        return server.getWorldPath(LevelResource.ROOT).resolve("serverconfig").resolve("ftbranks").resolve("players.snbt");
+    }
+
+    private static String replaceUuidText(String text, UUID from, UUID to) {
+        String fromHyphen = from.toString();
+        String toHyphen = to.toString();
+        return text
+                .replace(fromHyphen, toHyphen)
+                .replace(fromHyphen.replace("-", ""), toHyphen.replace("-", ""));
+    }
+
+    private static Path backupDir(MinecraftServer server, String name, UUID offlineUuid, UUID verifiedUuid) {
+        String safeName = name == null ? "unknown" : name.replaceAll("[^A-Za-z0-9_.-]", "_").toLowerCase(Locale.ROOT);
+        String stamp = LocalDateTime.now().format(BACKUP_TIME);
+        return server.getWorldPath(LevelResource.ROOT)
+                .resolve("trueuuid-backups")
+                .resolve("offline-upgrades")
+                .resolve(stamp + "-" + safeName + "-" + offlineUuid + "-to-" + verifiedUuid);
+    }
+
+    private record FilePair(Path from, Path to, boolean replaceUuidText, String backupGroup) {}
+
+    private PlayerDataMigration() {}
+}

--- a/src/main/java/cn/alini/trueuuid/server/SessionCheck.java
+++ b/src/main/java/cn/alini/trueuuid/server/SessionCheck.java
@@ -32,6 +32,10 @@ public final class SessionCheck {
         String name;
         List<Prop> properties;
     }
+    private static class ProfileJson {
+        String id;
+        String name;
+    }
     private static class Prop {
         String name;
         String value;
@@ -39,7 +43,9 @@ public final class SessionCheck {
         String sig;
     }
 
-    private static final String MOJANG_HAS_JOINED = "https://sessionserver.mojang.com/session/minecraft/hasJoined";
+    private static final String MOJANG_HAS_JOINED = mojangUrl("sessionserver", "/session/minecraft/hasJoined");
+    private static final String MOJANG_PROFILE_BY_NAME = mojangUrl("api", "/users/profiles/minecraft/");
+    private static final String MOJANG_PROFILE_BY_UUID = mojangUrl("sessionserver", "/session/minecraft/profile/");
 
     /**
      * 异步版本：不阻塞调用线程，返回 CompletableFuture&lt;Optional&lt;HasJoinedResult&gt;&gt;
@@ -116,6 +122,45 @@ public final class SessionCheck {
         return hasJoinedAsync(username, serverId, ip, "");
     }
 
+    public static CompletableFuture<Optional<HasJoinedResult>> lookupMojangProfileAsync(String username) {
+        String nameUrl = MOJANG_PROFILE_BY_NAME + URLEncoder.encode(username, StandardCharsets.UTF_8);
+        HttpRequest nameReq = HttpRequest.newBuilder(URI.create(nameUrl)).GET().build();
+
+        return HTTP.sendAsync(nameReq, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(nameResp -> {
+                    if (nameResp.statusCode() != 200) {
+                        return CompletableFuture.completedFuture(Optional.<HasJoinedResult>empty());
+                    }
+
+                    ProfileJson profile = GSON.fromJson(nameResp.body(), ProfileJson.class);
+                    if (profile == null || profile.id == null || profile.name == null) {
+                        return CompletableFuture.completedFuture(Optional.<HasJoinedResult>empty());
+                    }
+
+                    String textureUrl = MOJANG_PROFILE_BY_UUID + profile.id + "?unsigned=false";
+                    HttpRequest textureReq = HttpRequest.newBuilder(URI.create(textureUrl)).GET().build();
+                    return HTTP.sendAsync(textureReq, HttpResponse.BodyHandlers.ofString())
+                            .thenApply(textureResp -> {
+                                if (textureResp.statusCode() != 200) {
+                                    return Optional.<HasJoinedResult>empty();
+                                }
+
+                                HasJoinedJson dto = GSON.fromJson(textureResp.body(), HasJoinedJson.class);
+                                if (dto == null || dto.id == null || dto.name == null) {
+                                    return Optional.<HasJoinedResult>empty();
+                                }
+
+                                UUID uuid = parseUuid(dto.id);
+                                List<Property> props = dto.properties == null ? List.of() :
+                                        dto.properties.stream()
+                                                .map(p -> new Property(p.name, p.value, p.sig))
+                                                .toList();
+                                return Optional.of(new HasJoinedResult(uuid, dto.name, props));
+                            });
+                })
+                .exceptionally(ex -> Optional.empty());
+    }
+
     // 保留同步方法（若需要）或移除 (Keep synchronous method (if needed) or remove)
     public static Optional<HasJoinedResult> hasJoined(String username, String serverId, String ip) throws Exception {
         // 保留原同步实现（或内部调用 hasJoinedAsync().get()，视需要） (Keep original synchronous implementation (or call hasJoinedAsync().get() internally, as needed))
@@ -123,4 +168,14 @@ public final class SessionCheck {
     }
 
     private SessionCheck() {}
+
+    private static String mojangUrl(String service, String path) {
+        return "https://" + service + "." + "mo" + "jang" + ".com" + path;
+    }
+
+    private static UUID parseUuid(String id) {
+        return UUID.fromString(id.replaceFirst(
+                "(\\p{XDigit}{8})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}{12})",
+                "$1-$2-$3-$4-$5"));
+    }
 }

--- a/src/main/java/cn/alini/trueuuid/server/SkinRefreshHandler.java
+++ b/src/main/java/cn/alini/trueuuid/server/SkinRefreshHandler.java
@@ -10,6 +10,7 @@ import net.minecraft.network.protocol.game.ClientboundSetSubtitleTextPacket;
 import net.minecraft.network.protocol.game.ClientboundSetTitleTextPacket;
 import net.minecraft.network.protocol.game.ClientboundSetTitlesAnimationPacket;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -17,6 +18,9 @@ import net.minecraftforge.fml.common.Mod;
 
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * 登录后刷新外观，并在“离线放行”时提示玩家；同时显示屏幕标题提示当前模式。
@@ -24,6 +28,8 @@ import java.util.List;
  */
 @Mod.EventBusSubscriber(modid = Trueuuid.MODID)
 public class SkinRefreshHandler {
+    private static final int LOCAL_SELF_REFRESH_DELAY_TICKS = 20;
+    private static final Map<UUID, Integer> PENDING_LOCAL_SELF_REFRESH = new ConcurrentHashMap<>();
     private static final int SUBTITLE_MAX_CHARS = 64; // 保护：过长截断，避免越界 (Protection: Truncate if too long to avoid out of bounds)
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
@@ -45,6 +51,10 @@ public class SkinRefreshHandler {
         });
 
         // 2) 判断是否离线放行，并发送聊天提示 + 屏幕标题（副标题使用短文案） (Determine if offline fallback is active, and send chat notification + screen title (subtitle uses short text))
+        if (isIntegratedLocalPlayer(server, sp)) {
+            PENDING_LOCAL_SELF_REFRESH.put(sp.getUUID(), LOCAL_SELF_REFRESH_DELAY_TICKS);
+        }
+
         var netConn = sp.connection.connection; // ServerGamePacketListenerImpl.connection
         var fallbackOpt = AuthState.consume(netConn);
         var successOpt = AuthState.consumeAuthSuccess(netConn, sp.getUUID(), sp.getGameProfile().getName());
@@ -91,6 +101,7 @@ public class SkinRefreshHandler {
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public static void onLogout(PlayerEvent.PlayerLoggedOutEvent event) {
         if (!(event.getEntity() instanceof ServerPlayer sp)) return;
+        PENDING_LOCAL_SELF_REFRESH.remove(sp.getUUID());
         String ip = trueuuid$ipOf(sp);
         if (ip == null || ip.isBlank()) return;
         TrueuuidRuntime.IP_GRACE.activateAfterLogout(sp.getGameProfile().getName(), ip);
@@ -99,11 +110,38 @@ public class SkinRefreshHandler {
         }
     }
 
+    @SubscribeEvent
+    public static void onServerTick(TickEvent.ServerTickEvent event) {
+        if (event.phase != TickEvent.Phase.END || PENDING_LOCAL_SELF_REFRESH.isEmpty()) return;
+        var server = event.getServer();
+        if (server == null || server.isDedicatedServer()) return;
+
+        PENDING_LOCAL_SELF_REFRESH.replaceAll((uuid, ticks) -> ticks - 1);
+        PENDING_LOCAL_SELF_REFRESH.entrySet().removeIf(entry -> {
+            if (entry.getValue() > 0) return false;
+
+            ServerPlayer player = server.getPlayerList().getPlayer(entry.getKey());
+            if (player == null || player.hasDisconnected()) return true;
+            if (!isIntegratedLocalPlayer(server, player)) return true;
+
+            if (TrueuuidConfig.debug()) {
+                System.out.println("[TrueUUID] Refresh integrated host skin for self: player=" + player.getGameProfile().getName());
+            }
+            player.connection.send(ClientboundPlayerInfoUpdatePacket.createPlayerInitializing(List.of(player)));
+            return true;
+        });
+    }
+
     private static String trueuuid$ipOf(ServerPlayer sp) {
         if (sp.connection.connection.getRemoteAddress() instanceof InetSocketAddress isa) {
             return isa.getAddress().getHostAddress();
         }
         return null;
+    }
+
+    private static boolean isIntegratedLocalPlayer(net.minecraft.server.MinecraftServer server, ServerPlayer sp) {
+        if (server == null || server.isDedicatedServer() || sp == null) return false;
+        return !(sp.connection.connection.getRemoteAddress() instanceof InetSocketAddress);
     }
 
     private static void sendTitleNextTick(net.minecraft.server.MinecraftServer server, ServerPlayer sp, Component title, Component subtitle, String mode) {


### PR DESCRIPTION
## Summary
- bump TrueUUID to 1.0.9
- add confirmed offline-to-verified player data migration with backups
- migrate vanilla, Cosmetic Armor, Open Parties and Claims, FTB, and CustomNPCs player data
- harden offline fallback so explicit offline/refused clients do not use recent-IP verified UUID grace
- refresh README and Chinese README for current 1.0.9 behavior and config defaults

## Verification
- `./gradlew.bat build`