### PR TITLE
修复迁移备份与皮肤站来源显示（Forge 1.20.1）

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ mod_name=TrueUUID
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU LGPL 3.0
 # The mod version. See https://semver.org/
-mod_version=1.1.0
+mod_version=1.1.2
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/cn/alini/trueuuid/mixin/client/ClientHandshakeMixin.java
+++ b/src/main/java/cn/alini/trueuuid/mixin/client/ClientHandshakeMixin.java
@@ -30,6 +30,7 @@ import java.util.function.Consumer;
 public abstract class ClientHandshakeMixin {
     @Shadow private Connection connection;
     @Shadow private Consumer<Component> updateStatus;
+    @Unique private String trueuuid$lastHasJoinedUrl = "";
 
     @Inject(method = "handleCustomQuery", at = @At("HEAD"), cancellable = true)
     private void trueuuid$onCustomQuery(ClientboundCustomQueryPacket packet, CallbackInfo ci) {
@@ -62,7 +63,7 @@ public abstract class ClientHandshakeMixin {
         int transactionId = packet.getTransactionId();
 
         if (offlineUpgradeAvailable && NetIds.MIGRATION_CONFIRM_SERVER_ID.equals(serverId)) {
-            trueuuid$confirmOfflinePlayerDataUpgrade(mc, offlineUuid, offlineDataSummary, "", loginConnection, transactionId);
+            trueuuid$confirmOfflinePlayerDataUpgrade(mc, offlineUuid, offlineDataSummary, this.trueuuid$lastHasJoinedUrl, loginConnection, transactionId);
             ci.cancel();
             return;
         }
@@ -76,6 +77,7 @@ public abstract class ClientHandshakeMixin {
 
         // 在调用 joinServer 之前先读取 CHECK_URL，因为 joinServer 是一次性的。
         String hasJoinedUrl = trueuuid$resolveHasJoinedUrl();
+        this.trueuuid$lastHasJoinedUrl = hasJoinedUrl;
         final boolean upgradeAvailable = offlineUpgradeAvailable;
         final String upgradeOfflineUuid = offlineUuid;
         final String upgradeDataSummary = offlineDataSummary;

--- a/src/main/java/cn/alini/trueuuid/server/PlayerDataMigration.java
+++ b/src/main/java/cn/alini/trueuuid/server/PlayerDataMigration.java
@@ -61,7 +61,7 @@ public final class PlayerDataMigration {
                 new FilePair(playerData(server, data.offlineUuid()), playerData(server, verifiedUuid), false, "vanilla"),
                 new FilePair(playerDataOld(server, data.offlineUuid()), playerDataOld(server, verifiedUuid), false, "vanilla"),
                 new FilePair(cosmeticArmor(server, data.offlineUuid()), cosmeticArmor(server, verifiedUuid), false, "cosarmor"),
-                new FilePair(advancements(server, data.offlineUuid()), advancements(server, verifiedUuid), false, "vanilla"),
+                new FilePair(advancements(server, data.offlineUuid()), advancements(server, verifiedUuid), false, "vanilla/advancements"),
                 new FilePair(stats(server, data.offlineUuid()), stats(server, verifiedUuid), false, "vanilla"),
                 new FilePair(opacPlayerClaims(server, data.offlineUuid()), opacPlayerClaims(server, verifiedUuid), false, "opac"),
                 new FilePair(opacPlayerConfig(server, data.offlineUuid()), opacPlayerConfig(server, verifiedUuid), true, "opac"),
@@ -78,9 +78,9 @@ public final class PlayerDataMigration {
         for (FilePair pair : pairs) {
             if (!Files.exists(pair.from())) continue;
             Files.createDirectories(pair.to().getParent());
-            backupFile(pair.from(), backupDir.resolve("offline").resolve(pair.backupGroup()).resolve(pair.from().getFileName()));
+            backupFile(pair.from(), backupDir.resolve("offline").resolve(pair.backupRelativeDir()).resolve(pair.from().getFileName()));
             if (Files.exists(pair.to())) {
-                backupFile(pair.to(), backupDir.resolve("verified-existing").resolve(pair.backupGroup()).resolve(pair.to().getFileName()));
+                backupFile(pair.to(), backupDir.resolve("verified-existing").resolve(pair.backupRelativeDir()).resolve(pair.to().getFileName()));
             }
             if (pair.replaceUuidText()) {
                 String text = Files.readString(pair.from(), StandardCharsets.UTF_8);
@@ -104,7 +104,7 @@ public final class PlayerDataMigration {
                 new FilePair(playerData(server, data.offlineUuid()), playerData(server, data.offlineUuid()), false, "vanilla"),
                 new FilePair(playerDataOld(server, data.offlineUuid()), playerDataOld(server, data.offlineUuid()), false, "vanilla"),
                 new FilePair(cosmeticArmor(server, data.offlineUuid()), cosmeticArmor(server, data.offlineUuid()), false, "cosarmor"),
-                new FilePair(advancements(server, data.offlineUuid()), advancements(server, data.offlineUuid()), false, "vanilla"),
+                new FilePair(advancements(server, data.offlineUuid()), advancements(server, data.offlineUuid()), false, "vanilla/advancements"),
                 new FilePair(stats(server, data.offlineUuid()), stats(server, data.offlineUuid()), false, "vanilla"),
                 new FilePair(opacPlayerClaims(server, data.offlineUuid()), opacPlayerClaims(server, data.offlineUuid()), false, "opac"),
                 new FilePair(opacPlayerConfig(server, data.offlineUuid()), opacPlayerConfig(server, data.offlineUuid()), true, "opac"),
@@ -121,7 +121,7 @@ public final class PlayerDataMigration {
         int cleaned = 0;
         for (FilePair file : files) {
             if (!Files.exists(file.from())) continue;
-            Path backup = backupDir.resolve(file.backupGroup()).resolve(file.from().getFileName());
+            Path backup = backupDir.resolve(file.backupRelativeDir()).resolve(file.from().getFileName());
             Files.createDirectories(backup.getParent());
             Files.move(file.from(), backup, StandardCopyOption.REPLACE_EXISTING);
             cleaned++;
@@ -261,7 +261,7 @@ public final class PlayerDataMigration {
                 .resolve(stamp + "-" + safeName + "-" + offlineUuid);
     }
 
-    private record FilePair(Path from, Path to, boolean replaceUuidText, String backupGroup) {}
+    private record FilePair(Path from, Path to, boolean replaceUuidText, String backupRelativeDir) {}
 
     private PlayerDataMigration() {}
 }


### PR DESCRIPTION
## 内容

- 修复 advancements 与 stats 使用同名 JSON 备份路径导致进度备份被覆盖的问题，关联 #27
- 在第二阶段迁移确认中保留皮肤站 hasJoined 来源，避免错误显示为正版登录
- 版本推进到 1.1.2

## 效果

- advancements 保存到独立的 vanilla/advancements 目录
- 升级备份、已有正版数据备份和离线清理均不会再覆盖进度数据
- Mojang 与 Yggdrasil 迁移确认显示正确的认证来源

## 验证

- JDK 17
- .\\gradlew.bat clean build --no-daemon